### PR TITLE
feature: implement LRS feature (#29)

### DIFF
--- a/LinguaPal/LinguaPal/urls.py
+++ b/LinguaPal/LinguaPal/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     # API v1
     path('api/v1/', include('accounts.urls')),
     path('api/v1/', include('words.urls')),
+    path('api/v1/lrs/', include('lrs.urls', namespace='lrs')),
     # API Documentation
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),

--- a/LinguaPal/lrs/authentication.py
+++ b/LinguaPal/lrs/authentication.py
@@ -1,0 +1,180 @@
+"""
+LRS Authentication
+
+Custom authentication classes for xAPI LRS endpoints.
+Supports Basic Auth using LRSCredential model.
+"""
+
+import base64
+import logging
+
+from django.utils import timezone
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+from .models import LRSCredential
+
+logger = logging.getLogger(__name__)
+
+
+class LRSBasicAuthentication(BaseAuthentication):
+    """
+    HTTP Basic authentication for LRS xAPI endpoints.
+
+    Uses LRSCredential model for key/secret validation.
+    Updates last_used_at on successful authentication.
+
+    Usage:
+        Authorization: Basic base64(key:secret)
+
+    Example:
+        key = "abc123"
+        secret = "secretpassword"
+        header = f"Basic {base64.b64encode(b'abc123:secretpassword').decode()}"
+    """
+
+    def authenticate(self, request):
+        """
+        Authenticate the request and return a tuple of (user, credential).
+
+        Returns None if Basic auth header not present (allows other auths).
+        Raises AuthenticationFailed if credentials are invalid.
+        """
+        auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+
+        if not auth_header.startswith('Basic '):
+            return None
+
+        try:
+            # Decode Basic auth credentials
+            encoded_credentials = auth_header.split(' ', 1)[1]
+            decoded_credentials = base64.b64decode(encoded_credentials).decode('utf-8')
+            key, secret = decoded_credentials.split(':', 1)
+        except (ValueError, UnicodeDecodeError, IndexError) as e:
+            logger.warning(f"Invalid Basic auth header format: {e}")
+            raise AuthenticationFailed('Invalid Basic auth header format')
+
+        # Look up credential by key
+        try:
+            credential = LRSCredential.objects.get(key=key)
+        except LRSCredential.DoesNotExist:
+            logger.warning(f"LRS credential not found: {key}")
+            raise AuthenticationFailed('Invalid credentials')
+
+        # Check if credential is active
+        if not credential.is_active:
+            logger.warning(f"LRS credential is inactive: {key}")
+            raise AuthenticationFailed('Credential is inactive')
+
+        # Verify secret
+        if not credential.check_secret(secret):
+            logger.warning(f"Invalid secret for LRS credential: {key}")
+            raise AuthenticationFailed('Invalid credentials')
+
+        # Update last used timestamp
+        credential.update_last_used()
+
+        logger.debug(f"LRS authentication successful: {credential.name}")
+
+        # Return (user, auth) - user is the created_by user, auth is the credential
+        return (credential.created_by, credential)
+
+    def authenticate_header(self, request):
+        """
+        Return the WWW-Authenticate header value for 401 responses.
+        """
+        return 'Basic realm="LRS"'
+
+
+class LRSCredentialPermission:
+    """
+    Permission helper for checking LRS credential permissions.
+
+    Usage in views:
+        credential = request.auth
+        if not LRSCredentialPermission.has_permission(credential, 'write'):
+            raise PermissionDenied('Write permission required')
+    """
+
+    @staticmethod
+    def has_permission(credential: LRSCredential, permission: str) -> bool:
+        """
+        Check if the credential has the specified permission.
+
+        Args:
+            credential: LRSCredential instance (from request.auth)
+            permission: Permission to check ('read', 'write', 'delete')
+
+        Returns:
+            True if permission granted, False otherwise
+        """
+        if not credential:
+            return False
+
+        if not isinstance(credential, LRSCredential):
+            return False
+
+        return credential.has_permission(permission)
+
+    @staticmethod
+    def require_permission(credential: LRSCredential, permission: str):
+        """
+        Require the credential to have the specified permission.
+
+        Raises PermissionDenied if permission not granted.
+        """
+        from rest_framework.exceptions import PermissionDenied
+
+        if not LRSCredentialPermission.has_permission(credential, permission):
+            raise PermissionDenied(f'{permission.capitalize()} permission required')
+
+
+class IsLRSAuthenticated:
+    """
+    DRF Permission class for LRS-authenticated requests.
+
+    Ensures request is authenticated via LRS credentials.
+    """
+
+    def has_permission(self, request, view):
+        """Check if request has valid LRS authentication."""
+        return (
+            request.auth is not None and
+            isinstance(request.auth, LRSCredential)
+        )
+
+
+class HasLRSReadPermission:
+    """
+    DRF Permission class for LRS read operations.
+    """
+
+    def has_permission(self, request, view):
+        """Check if request has LRS read permission."""
+        if not isinstance(request.auth, LRSCredential):
+            return False
+        return request.auth.has_permission('read')
+
+
+class HasLRSWritePermission:
+    """
+    DRF Permission class for LRS write operations.
+    """
+
+    def has_permission(self, request, view):
+        """Check if request has LRS write permission."""
+        if not isinstance(request.auth, LRSCredential):
+            return False
+        return request.auth.has_permission('write')
+
+
+class HasLRSDeletePermission:
+    """
+    DRF Permission class for LRS delete operations.
+    """
+
+    def has_permission(self, request, view):
+        """Check if request has LRS delete permission."""
+        if not isinstance(request.auth, LRSCredential):
+            return False
+        return request.auth.has_permission('delete')

--- a/LinguaPal/lrs/elasticsearch.py
+++ b/LinguaPal/lrs/elasticsearch.py
@@ -128,19 +128,25 @@ def get_es_client() -> Optional[Elasticsearch]:
         user = getattr(settings, 'ELASTICSEARCH_USER', '')
         password = getattr(settings, 'ELASTICSEARCH_PASSWORD', '')
 
-        if user and password:
-            client = Elasticsearch(
-                hosts=[host],
-                basic_auth=(user, password)
-            )
-        else:
-            client = Elasticsearch(hosts=[host])
+        # Client options
+        client_options = {
+            'hosts': [host],
+            'request_timeout': 30,
+            'verify_certs': False,
+        }
 
-        # Test connection
-        if client.ping():
+        if user and password:
+            client_options['basic_auth'] = (user, password)
+
+        client = Elasticsearch(**client_options)
+
+        # Test connection using info() instead of ping() for ES 8.x compatibility
+        try:
+            info = client.info()
+            logger.debug(f"Connected to Elasticsearch: {info.get('version', {}).get('number', 'unknown')}")
             return client
-        else:
-            logger.warning("Elasticsearch ping failed")
+        except Exception as e:
+            logger.warning(f"Elasticsearch connection test failed: {e}")
             return None
 
     except ConnectionError as e:
@@ -161,6 +167,36 @@ def get_client() -> Optional[Elasticsearch]:
     if _es_client is None:
         _es_client = get_es_client()
     return _es_client
+
+
+# Module-level client accessor (lazy)
+class _ESClientAccessor:
+    """Lazy accessor for Elasticsearch client."""
+    _client = None
+
+    def __getattr__(self, name):
+        if self._client is None:
+            self._client = get_client()
+        if self._client is None:
+            raise RuntimeError("Elasticsearch client not available")
+        return getattr(self._client, name)
+
+    def __bool__(self):
+        if self._client is None:
+            self._client = get_client()
+        return self._client is not None
+
+
+es_client = _ESClientAccessor()
+
+
+def index_statement_to_dict(statement) -> Dict:
+    """
+    Convert XAPIStatement to Elasticsearch document dict.
+
+    Alias for _statement_to_doc for external use.
+    """
+    return _statement_to_doc(statement)
 
 
 def create_indices():

--- a/LinguaPal/lrs/management/commands/backfill_statements.py
+++ b/LinguaPal/lrs/management/commands/backfill_statements.py
@@ -1,0 +1,404 @@
+"""
+Backfill xAPI Statements
+
+Management command to convert existing GanaQuiz and WordQuiz data
+to xAPI Statements for historical data migration.
+
+Usage:
+    python manage.py backfill_statements
+    python manage.py backfill_statements --quiz-type=gana
+    python manage.py backfill_statements --quiz-type=word
+    python manage.py backfill_statements --dry-run
+"""
+
+import uuid
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from words.models import GanaQuiz, GanaQuizQuestion, WordQuiz, WordQuizQuestion
+from lrs.models import XAPIStatement
+from lrs.constants import (
+    XAPIVerb,
+    XAPIActivityType,
+    QuizType,
+    LINGUAPAL_BASE_IRI,
+    DEFAULT_MASTERY_SCORE,
+)
+
+
+class Command(BaseCommand):
+    help = 'Backfill xAPI Statements from existing quiz data'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--quiz-type',
+            type=str,
+            choices=['gana', 'word', 'all'],
+            default='all',
+            help='Quiz type to backfill (default: all)',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Run without creating statements (preview only)',
+        )
+        parser.add_argument(
+            '--batch-size',
+            type=int,
+            default=100,
+            help='Number of quizzes to process per batch (default: 100)',
+        )
+        parser.add_argument(
+            '--skip-existing',
+            action='store_true',
+            default=True,
+            help='Skip quizzes that already have statements (default: True)',
+        )
+
+    def handle(self, *args, **options):
+        quiz_type = options['quiz_type']
+        dry_run = options['dry_run']
+        batch_size = options['batch_size']
+        skip_existing = options['skip_existing']
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('DRY RUN - No statements will be created'))
+
+        stats = {
+            'gana_quizzes': 0,
+            'gana_statements': 0,
+            'word_quizzes': 0,
+            'word_statements': 0,
+            'skipped': 0,
+            'errors': 0,
+        }
+
+        if quiz_type in ['gana', 'all']:
+            self.backfill_gana_quizzes(dry_run, batch_size, skip_existing, stats)
+
+        if quiz_type in ['word', 'all']:
+            self.backfill_word_quizzes(dry_run, batch_size, skip_existing, stats)
+
+        # Summary
+        self.stdout.write('\n' + '=' * 50)
+        self.stdout.write(self.style.SUCCESS('Backfill Summary:'))
+        self.stdout.write(f"  Gana Quizzes processed: {stats['gana_quizzes']}")
+        self.stdout.write(f"  Gana Statements created: {stats['gana_statements']}")
+        self.stdout.write(f"  Word Quizzes processed: {stats['word_quizzes']}")
+        self.stdout.write(f"  Word Statements created: {stats['word_statements']}")
+        self.stdout.write(f"  Skipped (existing): {stats['skipped']}")
+        self.stdout.write(f"  Errors: {stats['errors']}")
+        total_statements = stats['gana_statements'] + stats['word_statements']
+        self.stdout.write(f"  Total statements: {total_statements}")
+
+    def backfill_gana_quizzes(self, dry_run, batch_size, skip_existing, stats):
+        """Backfill statements for GanaQuiz records."""
+        self.stdout.write('\nProcessing Gana Quizzes...')
+
+        quizzes = GanaQuiz.objects.select_related('user').prefetch_related(
+            'questions__word'
+        ).order_by('id')
+
+        total = quizzes.count()
+        self.stdout.write(f'  Found {total} quizzes')
+
+        for i, quiz in enumerate(quizzes.iterator(chunk_size=batch_size)):
+            if i % 10 == 0:
+                self.stdout.write(f'  Processing quiz {i + 1}/{total}...')
+
+            # Check if already processed
+            if skip_existing:
+                existing = XAPIStatement.objects.filter(
+                    object_id=f"{LINGUAPAL_BASE_IRI}/quiz/{QuizType.GANA_QUIZ}/{quiz.id}",
+                    verb_id=XAPIVerb.INITIALIZED,
+                ).exists()
+                if existing:
+                    stats['skipped'] += 1
+                    continue
+
+            try:
+                statements = self._create_gana_quiz_statements(quiz, dry_run)
+                stats['gana_quizzes'] += 1
+                stats['gana_statements'] += len(statements)
+            except Exception as e:
+                self.stdout.write(self.style.ERROR(f'  Error processing quiz {quiz.id}: {e}'))
+                stats['errors'] += 1
+
+    def backfill_word_quizzes(self, dry_run, batch_size, skip_existing, stats):
+        """Backfill statements for WordQuiz records."""
+        self.stdout.write('\nProcessing Word Quizzes...')
+
+        quizzes = WordQuiz.objects.select_related(
+            'user', 'learning_language', 'native_language'
+        ).prefetch_related('questions__word').order_by('id')
+
+        total = quizzes.count()
+        self.stdout.write(f'  Found {total} quizzes')
+
+        for i, quiz in enumerate(quizzes.iterator(chunk_size=batch_size)):
+            if i % 10 == 0:
+                self.stdout.write(f'  Processing quiz {i + 1}/{total}...')
+
+            # Check if already processed
+            if skip_existing:
+                existing = XAPIStatement.objects.filter(
+                    object_id=f"{LINGUAPAL_BASE_IRI}/quiz/{QuizType.WORD_QUIZ}/{quiz.id}",
+                    verb_id=XAPIVerb.INITIALIZED,
+                ).exists()
+                if existing:
+                    stats['skipped'] += 1
+                    continue
+
+            try:
+                statements = self._create_word_quiz_statements(quiz, dry_run)
+                stats['word_quizzes'] += 1
+                stats['word_statements'] += len(statements)
+            except Exception as e:
+                self.stdout.write(self.style.ERROR(f'  Error processing quiz {quiz.id}: {e}'))
+                stats['errors'] += 1
+
+    @transaction.atomic
+    def _create_gana_quiz_statements(self, quiz, dry_run):
+        """Create xAPI statements for a single GanaQuiz."""
+        statements = []
+        registration = uuid.uuid4()
+        user = quiz.user
+        category = QuizType.GANA_QUIZ
+        object_id = f"{LINGUAPAL_BASE_IRI}/quiz/{category}/{quiz.id}"
+
+        # 1. INITIALIZED statement
+        if not dry_run:
+            stmt = XAPIStatement.objects.create(
+                actor_user=user,
+                actor_mbox=user.email,
+                actor_name=user.username or user.email,
+                verb_id=XAPIVerb.INITIALIZED,
+                verb_display='initialized',
+                object_id=object_id,
+                object_definition={
+                    'type': XAPIActivityType.ASSESSMENT,
+                    'name': {'ko': f'가나 퀴즈 #{quiz.id}'},
+                    'description': {'ko': f'{quiz.get_character_set_display()} {quiz.get_quiz_type_display()}'},
+                },
+                context_registration=registration,
+                context_extensions={
+                    'quiz_type': quiz.quiz_type,
+                    'character_set': quiz.character_set,
+                    'total_questions': quiz.total_questions,
+                },
+                timestamp=quiz.started_at,
+            )
+            statements.append(stmt)
+        else:
+            statements.append({'verb': 'initialized', 'quiz_id': quiz.id})
+
+        # 2. ANSWERED statements for each question
+        for question in quiz.questions.filter(answered_at__isnull=False):
+            question_object_id = f"{LINGUAPAL_BASE_IRI}/quiz/{category}/{quiz.id}/question/{question.id}"
+
+            if not dry_run:
+                stmt = XAPIStatement.objects.create(
+                    actor_user=user,
+                    actor_mbox=user.email,
+                    actor_name=user.username or user.email,
+                    verb_id=XAPIVerb.ANSWERED,
+                    verb_display='answered',
+                    object_id=question_object_id,
+                    object_definition={
+                        'type': XAPIActivityType.QUESTION,
+                        'name': {'ko': f'문제 #{question.question_number}'},
+                    },
+                    result_success=question.is_correct,
+                    result_response=question.user_answer,
+                    context_registration=registration,
+                    context_extensions={
+                        'question_number': question.question_number,
+                        'correct_answer': question.correct_answer,
+                        'word': question.word.text if question.word else None,
+                    },
+                    timestamp=question.answered_at,
+                )
+                statements.append(stmt)
+            else:
+                statements.append({'verb': 'answered', 'question_id': question.id})
+
+        # 3. COMPLETED and PASSED/FAILED statements if quiz is completed
+        if quiz.is_completed and quiz.completed_at:
+            score_scaled = quiz.correct_count / quiz.total_questions if quiz.total_questions > 0 else 0
+            passed = score_scaled >= DEFAULT_MASTERY_SCORE
+
+            if not dry_run:
+                # COMPLETED
+                stmt = XAPIStatement.objects.create(
+                    actor_user=user,
+                    actor_mbox=user.email,
+                    actor_name=user.username or user.email,
+                    verb_id=XAPIVerb.COMPLETED,
+                    verb_display='completed',
+                    object_id=object_id,
+                    object_definition={
+                        'type': XAPIActivityType.ASSESSMENT,
+                        'name': {'ko': f'가나 퀴즈 #{quiz.id}'},
+                    },
+                    result_completion=True,
+                    result_score_scaled=score_scaled,
+                    result_score_raw=quiz.correct_count,
+                    result_score_min=0,
+                    result_score_max=quiz.total_questions,
+                    context_registration=registration,
+                    context_extensions={'quiz_type': quiz.quiz_type},
+                    timestamp=quiz.completed_at,
+                )
+                statements.append(stmt)
+
+                # PASSED or FAILED
+                stmt = XAPIStatement.objects.create(
+                    actor_user=user,
+                    actor_mbox=user.email,
+                    actor_name=user.username or user.email,
+                    verb_id=XAPIVerb.PASSED if passed else XAPIVerb.FAILED,
+                    verb_display='passed' if passed else 'failed',
+                    object_id=object_id,
+                    object_definition={
+                        'type': XAPIActivityType.ASSESSMENT,
+                        'name': {'ko': f'가나 퀴즈 #{quiz.id}'},
+                    },
+                    result_success=passed,
+                    result_score_scaled=score_scaled,
+                    context_registration=registration,
+                    context_extensions={'mastery_score': DEFAULT_MASTERY_SCORE},
+                    timestamp=quiz.completed_at,
+                )
+                statements.append(stmt)
+            else:
+                statements.append({'verb': 'completed', 'quiz_id': quiz.id})
+                statements.append({'verb': 'passed' if passed else 'failed', 'quiz_id': quiz.id})
+
+        return statements
+
+    @transaction.atomic
+    def _create_word_quiz_statements(self, quiz, dry_run):
+        """Create xAPI statements for a single WordQuiz."""
+        statements = []
+        registration = uuid.uuid4()
+        user = quiz.user
+        category = QuizType.WORD_QUIZ
+        object_id = f"{LINGUAPAL_BASE_IRI}/quiz/{category}/{quiz.id}"
+
+        # 1. INITIALIZED statement
+        if not dry_run:
+            stmt = XAPIStatement.objects.create(
+                actor_user=user,
+                actor_mbox=user.email,
+                actor_name=user.username or user.email,
+                verb_id=XAPIVerb.INITIALIZED,
+                verb_display='initialized',
+                object_id=object_id,
+                object_definition={
+                    'type': XAPIActivityType.ASSESSMENT,
+                    'name': {'ko': f'단어 퀴즈 #{quiz.id}'},
+                    'description': {'ko': f'{quiz.learning_language.name_ko} {quiz.get_quiz_type_display()}'},
+                },
+                context_registration=registration,
+                context_extensions={
+                    'quiz_type': quiz.quiz_type,
+                    'learning_language': quiz.learning_language.code,
+                    'native_language': quiz.native_language.code,
+                    'total_questions': quiz.total_questions,
+                },
+                timestamp=quiz.started_at,
+            )
+            statements.append(stmt)
+        else:
+            statements.append({'verb': 'initialized', 'quiz_id': quiz.id})
+
+        # 2. ANSWERED statements for each question
+        for question in quiz.questions.filter(answered_at__isnull=False):
+            question_object_id = f"{LINGUAPAL_BASE_IRI}/quiz/{category}/{quiz.id}/question/{question.id}"
+
+            # Get correct answer
+            correct_answer = question.get_correct_answer(quiz.native_language)
+
+            if not dry_run:
+                stmt = XAPIStatement.objects.create(
+                    actor_user=user,
+                    actor_mbox=user.email,
+                    actor_name=user.username or user.email,
+                    verb_id=XAPIVerb.ANSWERED,
+                    verb_display='answered',
+                    object_id=question_object_id,
+                    object_definition={
+                        'type': XAPIActivityType.QUESTION,
+                        'name': {'ko': f'문제 #{question.question_number}'},
+                    },
+                    result_success=question.is_correct,
+                    result_response=question.user_answer,
+                    context_registration=registration,
+                    context_extensions={
+                        'question_number': question.question_number,
+                        'correct_answer': correct_answer,
+                        'word': question.word.text if question.word else None,
+                    },
+                    timestamp=question.answered_at,
+                )
+                statements.append(stmt)
+            else:
+                statements.append({'verb': 'answered', 'question_id': question.id})
+
+        # 3. COMPLETED and PASSED/FAILED statements if quiz is completed
+        if quiz.is_completed and quiz.completed_at:
+            score_scaled = quiz.correct_count / quiz.total_questions if quiz.total_questions > 0 else 0
+            passed = score_scaled >= DEFAULT_MASTERY_SCORE
+
+            if not dry_run:
+                # COMPLETED
+                stmt = XAPIStatement.objects.create(
+                    actor_user=user,
+                    actor_mbox=user.email,
+                    actor_name=user.username or user.email,
+                    verb_id=XAPIVerb.COMPLETED,
+                    verb_display='completed',
+                    object_id=object_id,
+                    object_definition={
+                        'type': XAPIActivityType.ASSESSMENT,
+                        'name': {'ko': f'단어 퀴즈 #{quiz.id}'},
+                    },
+                    result_completion=True,
+                    result_score_scaled=score_scaled,
+                    result_score_raw=quiz.correct_count,
+                    result_score_min=0,
+                    result_score_max=quiz.total_questions,
+                    context_registration=registration,
+                    context_extensions={
+                        'quiz_type': quiz.quiz_type,
+                        'learning_language': quiz.learning_language.code,
+                    },
+                    timestamp=quiz.completed_at,
+                )
+                statements.append(stmt)
+
+                # PASSED or FAILED
+                stmt = XAPIStatement.objects.create(
+                    actor_user=user,
+                    actor_mbox=user.email,
+                    actor_name=user.username or user.email,
+                    verb_id=XAPIVerb.PASSED if passed else XAPIVerb.FAILED,
+                    verb_display='passed' if passed else 'failed',
+                    object_id=object_id,
+                    object_definition={
+                        'type': XAPIActivityType.ASSESSMENT,
+                        'name': {'ko': f'단어 퀴즈 #{quiz.id}'},
+                    },
+                    result_success=passed,
+                    result_score_scaled=score_scaled,
+                    context_registration=registration,
+                    context_extensions={'mastery_score': DEFAULT_MASTERY_SCORE},
+                    timestamp=quiz.completed_at,
+                )
+                statements.append(stmt)
+            else:
+                statements.append({'verb': 'completed', 'quiz_id': quiz.id})
+                statements.append({'verb': 'passed' if passed else 'failed', 'quiz_id': quiz.id})
+
+        return statements

--- a/LinguaPal/lrs/management/commands/reindex_statements.py
+++ b/LinguaPal/lrs/management/commands/reindex_statements.py
@@ -1,0 +1,193 @@
+"""
+Reindex xAPI Statements to Elasticsearch
+
+Management command to bulk index existing xAPI Statements
+to Elasticsearch for fast search and aggregation.
+
+Usage:
+    python manage.py reindex_statements
+    python manage.py reindex_statements --batch-size=500
+    python manage.py reindex_statements --dry-run
+"""
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from lrs.models import XAPIStatement
+
+
+class Command(BaseCommand):
+    help = 'Reindex xAPI Statements to Elasticsearch'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--batch-size',
+            type=int,
+            default=500,
+            help='Number of statements per bulk request (default: 500)',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Run without actually indexing (preview only)',
+        )
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            help='Force reindex even if document exists',
+        )
+
+    def handle(self, *args, **options):
+        batch_size = options['batch_size']
+        dry_run = options['dry_run']
+        force = options['force']
+
+        # Check if Elasticsearch is configured
+        es_host = getattr(settings, 'ELASTICSEARCH_HOST', None)
+        if not es_host:
+            self.stdout.write(self.style.WARNING(
+                'ELASTICSEARCH_HOST not configured in settings. Skipping Elasticsearch indexing.'
+            ))
+            return
+
+        try:
+            from lrs.elasticsearch import get_client, STATEMENT_INDEX, index_statement_to_dict
+        except ImportError as e:
+            self.stdout.write(self.style.ERROR(f'Could not import elasticsearch module: {e}'))
+            return
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('DRY RUN - No documents will be indexed'))
+
+        # Check Elasticsearch connection
+        es_client = get_client()
+        if not es_client:
+            self.stdout.write(self.style.ERROR('Cannot connect to Elasticsearch'))
+            return
+        self.stdout.write(self.style.SUCCESS('Connected to Elasticsearch'))
+
+        # Get total count
+        total = XAPIStatement.objects.count()
+        self.stdout.write(f'Found {total} statements to index')
+
+        if total == 0:
+            self.stdout.write('No statements to index')
+            return
+
+        # Process in batches
+        indexed = 0
+        errors = 0
+        skipped = 0
+
+        statements = XAPIStatement.objects.all().order_by('timestamp')
+
+        batch = []
+        for i, stmt in enumerate(statements.iterator(chunk_size=batch_size)):
+            doc = index_statement_to_dict(stmt)
+            batch.append({
+                '_index': STATEMENT_INDEX,
+                '_id': str(stmt.id),
+                '_source': doc,
+            })
+
+            if len(batch) >= batch_size:
+                if not dry_run:
+                    success, failed = self._bulk_index(es_client, batch, force)
+                    indexed += success
+                    errors += failed
+                else:
+                    indexed += len(batch)
+                batch = []
+
+                # Progress
+                progress = ((i + 1) / total) * 100
+                self.stdout.write(f'Progress: {i + 1}/{total} ({progress:.1f}%)')
+
+        # Index remaining batch
+        if batch:
+            if not dry_run:
+                success, failed = self._bulk_index(es_client, batch, force)
+                indexed += success
+                errors += failed
+            else:
+                indexed += len(batch)
+
+        # Refresh index
+        if not dry_run and indexed > 0:
+            try:
+                es_client.indices.refresh(index=STATEMENT_INDEX)
+                self.stdout.write('Index refreshed')
+            except Exception as e:
+                self.stdout.write(self.style.WARNING(f'Could not refresh index: {e}'))
+
+        # Summary
+        self.stdout.write('\n' + '=' * 50)
+        self.stdout.write(self.style.SUCCESS('Reindex Summary:'))
+        self.stdout.write(f'  Total statements: {total}')
+        self.stdout.write(f'  Successfully indexed: {indexed}')
+        self.stdout.write(f'  Errors: {errors}')
+        self.stdout.write(f'  Skipped: {skipped}')
+
+    def _bulk_index(self, es_client, batch, force):
+        """Perform bulk indexing."""
+        from elasticsearch.helpers import bulk, BulkIndexError
+
+        success = 0
+        failed = 0
+
+        try:
+            # Use bulk helper
+            if force:
+                # Delete and re-create
+                actions = []
+                for item in batch:
+                    actions.append({
+                        '_op_type': 'index',
+                        '_index': item['_index'],
+                        '_id': item['_id'],
+                        '_source': item['_source'],
+                    })
+                success_count, errors = bulk(
+                    es_client,
+                    actions,
+                    raise_on_error=False,
+                    raise_on_exception=False,
+                )
+                success = success_count
+                if errors:
+                    failed = len(errors)
+            else:
+                # Create only if not exists
+                actions = []
+                for item in batch:
+                    actions.append({
+                        '_op_type': 'create',
+                        '_index': item['_index'],
+                        '_id': item['_id'],
+                        '_source': item['_source'],
+                    })
+                try:
+                    success_count, errors = bulk(
+                        es_client,
+                        actions,
+                        raise_on_error=False,
+                        raise_on_exception=False,
+                    )
+                    success = success_count
+                    if errors:
+                        # Filter out "document already exists" errors
+                        real_errors = [
+                            e for e in errors
+                            if 'version_conflict_engine_exception' not in str(e)
+                        ]
+                        failed = len(real_errors)
+                except BulkIndexError as e:
+                    # Some documents may already exist
+                    success = len(batch) - len(e.errors)
+                    failed = len(e.errors)
+
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f'Bulk index error: {e}'))
+            failed = len(batch)
+
+        return success, failed

--- a/LinguaPal/lrs/serializers.py
+++ b/LinguaPal/lrs/serializers.py
@@ -1,0 +1,206 @@
+"""
+LRS Serializers
+
+Serializers for xAPI statements, cmi5 sessions, and dashboard data.
+"""
+
+from rest_framework import serializers
+
+from .models import XAPIStatement, CMI5Session, LRSCredential
+
+
+class XAPIStatementSerializer(serializers.ModelSerializer):
+    """Serializer for xAPI Statement model."""
+
+    actor = serializers.SerializerMethodField()
+    verb = serializers.SerializerMethodField()
+    object = serializers.SerializerMethodField()
+    result = serializers.SerializerMethodField()
+    context = serializers.SerializerMethodField()
+
+    class Meta:
+        model = XAPIStatement
+        fields = [
+            'id', 'actor', 'verb', 'object', 'result', 'context',
+            'timestamp', 'stored'
+        ]
+
+    def get_actor(self, obj):
+        return {
+            'objectType': 'Agent',
+            'mbox': f'mailto:{obj.actor_mbox}',
+            'name': obj.actor_name,
+        }
+
+    def get_verb(self, obj):
+        return {
+            'id': obj.verb_id,
+            'display': {'en-US': obj.verb_display}
+        }
+
+    def get_object(self, obj):
+        return {
+            'objectType': obj.object_type,
+            'id': obj.object_id,
+            'definition': obj.object_definition
+        }
+
+    def get_result(self, obj):
+        result = {}
+        if obj.result_success is not None:
+            result['success'] = obj.result_success
+        if obj.result_response:
+            result['response'] = obj.result_response
+        if obj.result_completion is not None:
+            result['completion'] = obj.result_completion
+
+        if obj.result_score_scaled is not None:
+            result['score'] = {'scaled': obj.result_score_scaled}
+            if obj.result_score_raw is not None:
+                result['score']['raw'] = obj.result_score_raw
+            if obj.result_score_min is not None:
+                result['score']['min'] = obj.result_score_min
+            if obj.result_score_max is not None:
+                result['score']['max'] = obj.result_score_max
+
+        return result if result else None
+
+    def get_context(self, obj):
+        context = {}
+        if obj.context_registration:
+            context['registration'] = str(obj.context_registration)
+        if obj.context_extensions:
+            context['extensions'] = obj.context_extensions
+        return context if context else None
+
+
+class XAPIStatementInputSerializer(serializers.Serializer):
+    """Serializer for incoming xAPI statements (POST)."""
+
+    id = serializers.UUIDField(required=False)
+    actor = serializers.DictField(required=True)
+    verb = serializers.DictField(required=True)
+    object = serializers.DictField(required=True)
+    result = serializers.DictField(required=False)
+    context = serializers.DictField(required=False)
+    timestamp = serializers.DateTimeField(required=False)
+
+    def validate_actor(self, value):
+        """Validate actor field."""
+        if 'mbox' not in value and 'account' not in value:
+            raise serializers.ValidationError("Actor must have mbox or account")
+        return value
+
+    def validate_verb(self, value):
+        """Validate verb field."""
+        if 'id' not in value:
+            raise serializers.ValidationError("Verb must have id")
+        return value
+
+    def validate_object(self, value):
+        """Validate object field."""
+        if 'id' not in value:
+            raise serializers.ValidationError("Object must have id")
+        return value
+
+
+class CMI5SessionSerializer(serializers.ModelSerializer):
+    """Serializer for cmi5 Session model."""
+
+    actor_email = serializers.EmailField(source='actor_user.email', read_only=True)
+    actor_name = serializers.CharField(source='actor_user.username', read_only=True)
+
+    class Meta:
+        model = CMI5Session
+        fields = [
+            'id', 'registration', 'actor_email', 'actor_name',
+            'au_id', 'au_type', 'au_object_id', 'state',
+            'mastery_score', 'launch_mode', 'move_on',
+            'launched_at', 'initialized_at', 'terminated_at',
+            'is_passed', 'is_completed', 'score_scaled'
+        ]
+        read_only_fields = ['id', 'registration', 'launched_at']
+
+
+class LRSCredentialSerializer(serializers.ModelSerializer):
+    """Serializer for LRS Credential model."""
+
+    created_by_email = serializers.EmailField(source='created_by.email', read_only=True)
+
+    class Meta:
+        model = LRSCredential
+        fields = [
+            'id', 'name', 'key', 'is_active', 'permissions',
+            'created_by_email', 'created_at', 'last_used_at'
+        ]
+        read_only_fields = ['id', 'key', 'created_at', 'last_used_at']
+
+
+class LRSCredentialCreateSerializer(serializers.Serializer):
+    """Serializer for creating LRS credentials."""
+
+    name = serializers.CharField(max_length=100)
+    permissions = serializers.ListField(
+        child=serializers.ChoiceField(choices=['read', 'write', 'delete']),
+        default=['read', 'write']
+    )
+
+
+# Dashboard Serializers
+
+class DashboardOverviewSerializer(serializers.Serializer):
+    """Serializer for dashboard overview data."""
+
+    total_users = serializers.IntegerField()
+    active_users = serializers.IntegerField()
+    total_quizzes = serializers.IntegerField()
+    completed_quizzes = serializers.IntegerField()
+    total_questions = serializers.IntegerField()
+    total_correct = serializers.IntegerField()
+    overall_accuracy = serializers.FloatField()
+    pass_rate = serializers.FloatField()
+    quiz_type_breakdown = serializers.DictField()
+
+
+class DashboardUserStatsSerializer(serializers.Serializer):
+    """Serializer for per-user dashboard stats."""
+
+    user_id = serializers.IntegerField()
+    email = serializers.EmailField()
+    username = serializers.CharField()
+    total_quizzes = serializers.IntegerField()
+    total_correct = serializers.IntegerField()
+    total_questions = serializers.IntegerField()
+    accuracy = serializers.FloatField()
+    last_activity = serializers.DateTimeField()
+
+
+class DashboardTrendSerializer(serializers.Serializer):
+    """Serializer for trend data."""
+
+    date = serializers.DateField()
+    quizzes_completed = serializers.IntegerField()
+    questions_answered = serializers.IntegerField()
+    correct_answers = serializers.IntegerField()
+    unique_users = serializers.IntegerField()
+
+
+class StatementQuerySerializer(serializers.Serializer):
+    """Serializer for statement query parameters."""
+
+    statementId = serializers.UUIDField(required=False)
+    agent = serializers.CharField(required=False)
+    verb = serializers.URLField(required=False)
+    activity = serializers.URLField(required=False)
+    registration = serializers.UUIDField(required=False)
+    since = serializers.DateTimeField(required=False)
+    until = serializers.DateTimeField(required=False)
+    limit = serializers.IntegerField(required=False, default=100, max_value=1000)
+    ascending = serializers.BooleanField(required=False, default=False)
+
+
+class LRSAboutSerializer(serializers.Serializer):
+    """Serializer for LRS About resource."""
+
+    version = serializers.ListField(child=serializers.CharField())
+    extensions = serializers.DictField(required=False)

--- a/LinguaPal/lrs/services.py
+++ b/LinguaPal/lrs/services.py
@@ -1,0 +1,396 @@
+"""
+LRS Services
+
+xAPI Statement builder and helper services.
+"""
+
+import uuid
+from typing import Optional, Dict, Any, List
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from .models import XAPIStatement, CMI5Session
+from .constants import (
+    XAPIVerb, CMI5Verb, XAPIActivityType, QuizType,
+    LINGUAPAL_BASE_IRI, DEFAULT_MASTERY_SCORE
+)
+
+
+class StatementBuilder:
+    """
+    Builder class for creating xAPI statements.
+
+    Usage:
+        statement = (
+            StatementBuilder(user)
+            .verb(XAPIVerb.ANSWERED)
+            .object_activity('quiz/gana/123', 'Gana Quiz', XAPIActivityType.ASSESSMENT)
+            .result(success=True, response='a', score=0.9)
+            .context(quiz_type='gana_to_romaji', question_number=5)
+            .build()
+        )
+    """
+
+    def __init__(self, user):
+        self.user = user
+        self._verb_id: Optional[str] = None
+        self._verb_display: Optional[str] = None
+        self._object_id: Optional[str] = None
+        self._object_type: str = 'Activity'
+        self._object_definition: Dict = {}
+        self._result: Dict = {}
+        self._context_registration: Optional[uuid.UUID] = None
+        self._context_extensions: Dict = {}
+        self._timestamp: Optional[timezone.datetime] = None
+
+    def verb(self, verb_id: str, display: str = None) -> 'StatementBuilder':
+        """Set the verb for this statement."""
+        self._verb_id = verb_id
+        self._verb_display = display or XAPIVerb.get_display(verb_id)
+        return self
+
+    def object_activity(
+        self,
+        activity_id: str,
+        name: str = None,
+        activity_type: str = None,
+        description: str = None
+    ) -> 'StatementBuilder':
+        """Set the object (Activity) for this statement."""
+        if not activity_id.startswith('http'):
+            activity_id = f"{LINGUAPAL_BASE_IRI}/{activity_id}"
+
+        self._object_id = activity_id
+        self._object_type = 'Activity'
+        self._object_definition = {}
+
+        if activity_type:
+            self._object_definition['type'] = activity_type
+        if name:
+            self._object_definition['name'] = {'ko': name}
+        if description:
+            self._object_definition['description'] = {'ko': description}
+
+        return self
+
+    def result(
+        self,
+        success: bool = None,
+        response: str = None,
+        score_scaled: float = None,
+        score_raw: float = None,
+        score_min: float = None,
+        score_max: float = None,
+        completion: bool = None,
+        duration: timedelta = None
+    ) -> 'StatementBuilder':
+        """Set the result for this statement."""
+        if success is not None:
+            self._result['success'] = success
+        if response is not None:
+            self._result['response'] = response
+        if score_scaled is not None:
+            self._result['score_scaled'] = score_scaled
+        if score_raw is not None:
+            self._result['score_raw'] = score_raw
+        if score_min is not None:
+            self._result['score_min'] = score_min
+        if score_max is not None:
+            self._result['score_max'] = score_max
+        if completion is not None:
+            self._result['completion'] = completion
+        if duration is not None:
+            self._result['duration'] = duration
+        return self
+
+    def context(
+        self,
+        registration: uuid.UUID = None,
+        **extensions
+    ) -> 'StatementBuilder':
+        """Set the context for this statement."""
+        if registration:
+            self._context_registration = registration
+        self._context_extensions.update(extensions)
+        return self
+
+    def timestamp(self, ts: timezone.datetime) -> 'StatementBuilder':
+        """Set a custom timestamp."""
+        self._timestamp = ts
+        return self
+
+    def build(self) -> XAPIStatement:
+        """Build and save the xAPI statement."""
+        if not self._verb_id:
+            raise ValueError("Verb is required")
+        if not self._object_id:
+            raise ValueError("Object is required")
+
+        statement = XAPIStatement(
+            actor_user=self.user,
+            actor_mbox=self.user.email,
+            actor_name=self.user.username or self.user.email,
+            verb_id=self._verb_id,
+            verb_display=self._verb_display,
+            object_type=self._object_type,
+            object_id=self._object_id,
+            object_definition=self._object_definition,
+            context_registration=self._context_registration,
+            context_extensions=self._context_extensions,
+        )
+
+        # Set result fields
+        if 'success' in self._result:
+            statement.result_success = self._result['success']
+        if 'response' in self._result:
+            statement.result_response = self._result['response']
+        if 'score_scaled' in self._result:
+            statement.result_score_scaled = self._result['score_scaled']
+        if 'score_raw' in self._result:
+            statement.result_score_raw = self._result['score_raw']
+        if 'score_min' in self._result:
+            statement.result_score_min = self._result['score_min']
+        if 'score_max' in self._result:
+            statement.result_score_max = self._result['score_max']
+        if 'completion' in self._result:
+            statement.result_completion = self._result['completion']
+        if 'duration' in self._result:
+            statement.result_duration = self._result['duration']
+
+        # Set timestamp
+        if self._timestamp:
+            statement.timestamp = self._timestamp
+
+        statement.save()
+        return statement
+
+    @classmethod
+    def create_from_data(cls, data: Dict[str, Any]) -> XAPIStatement:
+        """
+        Create a statement from a dictionary.
+
+        Used by Celery tasks for async statement creation.
+        """
+        from accounts.models import User
+
+        user_id = data.get('actor_user_id')
+        user = User.objects.get(pk=user_id)
+
+        builder = cls(user)
+
+        # Set verb
+        verb = data.get('verb')
+        if isinstance(verb, str):
+            # Map short verb names to full IRIs
+            verb_map = {
+                'initialized': XAPIVerb.INITIALIZED,
+                'answered': XAPIVerb.ANSWERED,
+                'progressed': XAPIVerb.PROGRESSED,
+                'completed': XAPIVerb.COMPLETED,
+                'passed': XAPIVerb.PASSED,
+                'failed': XAPIVerb.FAILED,
+                'terminated': XAPIVerb.TERMINATED,
+            }
+            verb = verb_map.get(verb, verb)
+        builder.verb(verb)
+
+        # Set object
+        object_id = data.get('object_id', '')
+        object_name = data.get('object_name')
+        object_type = data.get('object_type', XAPIActivityType.ASSESSMENT)
+        object_desc = data.get('object_description')
+        builder.object_activity(object_id, object_name, object_type, object_desc)
+
+        # Set result if present
+        result = data.get('result', {})
+        if result:
+            builder.result(
+                success=result.get('success'),
+                response=result.get('response'),
+                score_scaled=result.get('score_scaled'),
+                score_raw=result.get('score_raw'),
+                score_min=result.get('score_min'),
+                score_max=result.get('score_max'),
+                completion=result.get('completion'),
+            )
+
+        # Set context
+        context = data.get('context', {})
+        registration = context.pop('registration', None)
+        if registration:
+            if isinstance(registration, str):
+                registration = uuid.UUID(registration)
+            builder.context(registration=registration, **context)
+        elif context:
+            builder.context(**context)
+
+        return builder.build()
+
+
+class QuizStatementService:
+    """
+    Service for creating quiz-related xAPI statements.
+    """
+
+    @staticmethod
+    def quiz_initialized(
+        user,
+        quiz,
+        quiz_type: str,
+        registration: uuid.UUID = None
+    ) -> Dict[str, Any]:
+        """
+        Create data for INITIALIZED statement when quiz starts.
+
+        Returns data dict for async task.
+        """
+        # Determine quiz category
+        is_gana = hasattr(quiz, 'character_set')
+        category = QuizType.GANA_QUIZ if is_gana else QuizType.WORD_QUIZ
+
+        return {
+            'actor_user_id': user.id,
+            'verb': 'initialized',
+            'object_id': f"quiz/{category}/{quiz.id}",
+            'object_name': f"{'가나' if is_gana else '단어'} 퀴즈 #{quiz.id}",
+            'object_type': XAPIActivityType.ASSESSMENT,
+            'context': {
+                'registration': str(registration) if registration else str(uuid.uuid4()),
+                'quiz_type': quiz_type,
+                'total_questions': quiz.total_questions,
+            }
+        }
+
+    @staticmethod
+    def question_answered(
+        user,
+        quiz,
+        question,
+        user_answer: str,
+        is_correct: bool,
+        correct_answer: str,
+        registration: uuid.UUID = None
+    ) -> Dict[str, Any]:
+        """
+        Create data for ANSWERED statement when question is answered.
+        """
+        is_gana = hasattr(quiz, 'character_set')
+        category = QuizType.GANA_QUIZ if is_gana else QuizType.WORD_QUIZ
+
+        return {
+            'actor_user_id': user.id,
+            'verb': 'answered',
+            'object_id': f"quiz/{category}/{quiz.id}/question/{question.id}",
+            'object_name': f"문제 #{question.question_number}",
+            'object_type': XAPIActivityType.QUESTION,
+            'result': {
+                'success': is_correct,
+                'response': user_answer,
+            },
+            'context': {
+                'registration': str(registration) if registration else None,
+                'quiz_type': getattr(quiz, 'quiz_type', None),
+                'question_number': question.question_number,
+                'correct_answer': correct_answer,
+            }
+        }
+
+    @staticmethod
+    def quiz_completed(
+        user,
+        quiz,
+        registration: uuid.UUID = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Create data for completion statements (COMPLETED, PASSED/FAILED).
+
+        Returns list of statement data dicts.
+        """
+        is_gana = hasattr(quiz, 'character_set')
+        category = QuizType.GANA_QUIZ if is_gana else QuizType.WORD_QUIZ
+
+        score_scaled = quiz.correct_count / quiz.total_questions if quiz.total_questions > 0 else 0
+        mastery_score = getattr(settings, 'LRS_MASTERY_SCORE', DEFAULT_MASTERY_SCORE)
+        passed = score_scaled >= mastery_score
+
+        reg_str = str(registration) if registration else None
+
+        statements = []
+
+        # COMPLETED statement
+        statements.append({
+            'actor_user_id': user.id,
+            'verb': 'completed',
+            'object_id': f"quiz/{category}/{quiz.id}",
+            'object_name': f"{'가나' if is_gana else '단어'} 퀴즈 #{quiz.id}",
+            'object_type': XAPIActivityType.ASSESSMENT,
+            'result': {
+                'completion': True,
+                'score_scaled': score_scaled,
+                'score_raw': quiz.correct_count,
+                'score_min': 0,
+                'score_max': quiz.total_questions,
+            },
+            'context': {
+                'registration': reg_str,
+                'quiz_type': getattr(quiz, 'quiz_type', None),
+            }
+        })
+
+        # PASSED or FAILED statement
+        statements.append({
+            'actor_user_id': user.id,
+            'verb': 'passed' if passed else 'failed',
+            'object_id': f"quiz/{category}/{quiz.id}",
+            'object_name': f"{'가나' if is_gana else '단어'} 퀴즈 #{quiz.id}",
+            'object_type': XAPIActivityType.ASSESSMENT,
+            'result': {
+                'success': passed,
+                'score_scaled': score_scaled,
+            },
+            'context': {
+                'registration': reg_str,
+                'mastery_score': mastery_score,
+            }
+        })
+
+        return statements
+
+
+class CMI5SessionService:
+    """
+    Service for managing cmi5 sessions.
+    """
+
+    @staticmethod
+    def create_session(
+        user,
+        au_type: str,
+        au_object_id: int = None,
+        mastery_score: float = DEFAULT_MASTERY_SCORE
+    ) -> CMI5Session:
+        """Create a new cmi5 session."""
+        au_id = f"{LINGUAPAL_BASE_IRI}/au/{au_type}/{au_object_id or 'new'}"
+
+        session = CMI5Session.objects.create(
+            actor_user=user,
+            au_id=au_id,
+            au_type=au_type,
+            au_object_id=au_object_id,
+            mastery_score=mastery_score,
+        )
+        return session
+
+    @staticmethod
+    def get_active_session(user, au_type: str, au_object_id: int = None) -> Optional[CMI5Session]:
+        """Get an active (non-terminated) session."""
+        queryset = CMI5Session.objects.filter(
+            actor_user=user,
+            au_type=au_type,
+            state__in=[CMI5Session.SessionState.LAUNCHED, CMI5Session.SessionState.INITIALIZED]
+        )
+        if au_object_id:
+            queryset = queryset.filter(au_object_id=au_object_id)
+        return queryset.first()

--- a/LinguaPal/lrs/signals.py
+++ b/LinguaPal/lrs/signals.py
@@ -1,0 +1,77 @@
+"""
+LRS Signals
+
+Django signals for Elasticsearch synchronization.
+Statements are indexed via Celery tasks for async processing.
+"""
+
+import logging
+
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+from .models import XAPIStatement, CMI5Session
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=XAPIStatement)
+def index_statement_on_save(sender, instance, created, **kwargs):
+    """
+    Index xAPI statement in Elasticsearch when saved.
+
+    Uses Celery task for async indexing.
+    """
+    try:
+        from .tasks import index_statement_task
+        index_statement_task.delay(str(instance.id))
+        logger.debug(f"Queued statement for ES indexing: {instance.id}")
+    except Exception as exc:
+        # Don't fail if Celery is not available
+        logger.warning(f"Could not queue statement indexing: {exc}")
+
+
+@receiver(post_delete, sender=XAPIStatement)
+def delete_statement_from_es(sender, instance, **kwargs):
+    """
+    Delete statement from Elasticsearch when deleted from DB.
+
+    Note: We use synchronous delete here since deletes are less frequent
+    and we want to ensure consistency.
+    """
+    try:
+        from .elasticsearch import delete_statement
+        delete_statement(str(instance.id))
+        logger.debug(f"Deleted statement from ES: {instance.id}")
+    except Exception as exc:
+        logger.error(f"Error deleting statement from ES: {exc}")
+
+
+@receiver(post_save, sender=CMI5Session)
+def index_session_on_save(sender, instance, created, **kwargs):
+    """
+    Index cmi5 session in Elasticsearch when saved.
+
+    Uses Celery task for async indexing.
+    """
+    try:
+        from .tasks import index_session_task
+        index_session_task.delay(str(instance.id))
+    except Exception as exc:
+        # Don't fail if Celery is not available
+        logger.warning(f"Could not queue session indexing: {exc}")
+
+
+@receiver(post_delete, sender=CMI5Session)
+def delete_session_from_es(sender, instance, **kwargs):
+    """
+    Delete session from Elasticsearch when deleted from DB.
+    """
+    try:
+        from .elasticsearch import get_client, SESSION_INDEX
+        client = get_client()
+        if client:
+            client.delete(index=SESSION_INDEX, id=str(instance.id), ignore=[404])
+            logger.debug(f"Deleted session from ES: {instance.id}")
+    except Exception as exc:
+        logger.error(f"Error deleting session from ES: {exc}")

--- a/LinguaPal/lrs/tasks.py
+++ b/LinguaPal/lrs/tasks.py
@@ -1,0 +1,154 @@
+"""
+LRS Celery Tasks
+
+Async tasks for xAPI statement creation and Elasticsearch indexing.
+"""
+
+import logging
+from typing import Dict, Any, List
+
+from celery import shared_task
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def create_statement_task(self, statement_data: Dict[str, Any]) -> str:
+    """
+    Create an xAPI statement asynchronously.
+
+    Args:
+        statement_data: Dictionary containing statement data
+
+    Returns:
+        Statement ID as string
+    """
+    try:
+        from .services import StatementBuilder
+
+        statement = StatementBuilder.create_from_data(statement_data)
+        logger.info(f"Created statement: {statement.id}")
+
+        # Trigger ES indexing
+        index_statement_task.delay(str(statement.id))
+
+        return str(statement.id)
+
+    except Exception as exc:
+        logger.error(f"Error creating statement: {exc}")
+        self.retry(exc=exc)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=30)
+def index_statement_task(self, statement_id: str) -> bool:
+    """
+    Index a statement in Elasticsearch.
+
+    Args:
+        statement_id: UUID string of the statement
+
+    Returns:
+        True if successful
+    """
+    try:
+        from .elasticsearch import index_statement_by_id
+
+        result = index_statement_by_id(statement_id)
+        if result:
+            logger.info(f"Indexed statement: {statement_id}")
+        else:
+            logger.warning(f"Failed to index statement: {statement_id}")
+        return result
+
+    except Exception as exc:
+        logger.error(f"Error indexing statement {statement_id}: {exc}")
+        self.retry(exc=exc)
+
+
+@shared_task(bind=True)
+def bulk_index_task(self, statement_ids: List[str]) -> Dict[str, int]:
+    """
+    Bulk index multiple statements in Elasticsearch.
+
+    Args:
+        statement_ids: List of statement UUID strings
+
+    Returns:
+        Dict with 'success' and 'failed' counts
+    """
+    try:
+        from .models import XAPIStatement
+        from .elasticsearch import bulk_index_statements
+
+        statements = XAPIStatement.objects.filter(id__in=statement_ids)
+        result = bulk_index_statements(statements)
+        logger.info(f"Bulk indexed: {result}")
+        return result
+
+    except Exception as exc:
+        logger.error(f"Bulk indexing error: {exc}")
+        return {'success': 0, 'failed': len(statement_ids)}
+
+
+@shared_task
+def create_quiz_statements_task(quiz_data: Dict[str, Any]) -> List[str]:
+    """
+    Create multiple statements for quiz completion.
+
+    This is used when a quiz is completed to create:
+    - COMPLETED statement
+    - PASSED or FAILED statement
+
+    Args:
+        quiz_data: Dict containing 'statements' list
+
+    Returns:
+        List of created statement IDs
+    """
+    from .services import StatementBuilder
+
+    statement_ids = []
+    statements_data = quiz_data.get('statements', [])
+
+    for stmt_data in statements_data:
+        try:
+            statement = StatementBuilder.create_from_data(stmt_data)
+            statement_ids.append(str(statement.id))
+            logger.info(f"Created quiz statement: {statement.id}")
+        except Exception as exc:
+            logger.error(f"Error creating quiz statement: {exc}")
+
+    # Bulk index all created statements
+    if statement_ids:
+        bulk_index_task.delay(statement_ids)
+
+    return statement_ids
+
+
+@shared_task
+def index_session_task(session_id: str) -> bool:
+    """
+    Index a cmi5 session in Elasticsearch.
+
+    Args:
+        session_id: UUID string of the session
+
+    Returns:
+        True if successful
+    """
+    try:
+        from .models import CMI5Session
+        from .elasticsearch import index_session
+
+        session = CMI5Session.objects.get(id=session_id)
+        result = index_session(session)
+        if result:
+            logger.info(f"Indexed session: {session_id}")
+        return result
+
+    except CMI5Session.DoesNotExist:
+        logger.error(f"Session not found: {session_id}")
+        return False
+    except Exception as exc:
+        logger.error(f"Error indexing session {session_id}: {exc}")
+        return False

--- a/LinguaPal/lrs/tests.py
+++ b/LinguaPal/lrs/tests.py
@@ -1,0 +1,613 @@
+"""
+LRS App Tests
+
+Tests for xAPI statements, cmi5 sessions, dashboard APIs, and LRS credentials.
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase, APIClient
+from rest_framework import status
+
+from .models import XAPIStatement, CMI5Session, LRSCredential
+from .services import StatementBuilder, QuizStatementService
+from .constants import XAPIVerb, XAPIActivityType, QuizType, DEFAULT_MASTERY_SCORE
+
+
+User = get_user_model()
+
+
+class XAPIStatementModelTest(TestCase):
+    """Tests for XAPIStatement model."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com',
+            password='testpass123',
+            username='testuser'
+        )
+
+    def test_create_statement(self):
+        """Test creating a basic xAPI statement."""
+        statement = XAPIStatement.objects.create(
+            actor_user=self.user,
+            actor_mbox=self.user.email,
+            actor_name=self.user.username,
+            verb_id=XAPIVerb.ANSWERED,
+            verb_display='answered',
+            object_id='https://linguapal.com/quiz/gana_quiz/1/question/1',
+            object_definition={
+                'type': XAPIActivityType.QUESTION,
+                'name': {'ko': '문제 #1'}
+            },
+            result_success=True,
+            result_response='a',
+        )
+
+        self.assertIsNotNone(statement.id)
+        self.assertEqual(statement.actor_user, self.user)
+        self.assertEqual(statement.verb_id, XAPIVerb.ANSWERED)
+        self.assertTrue(statement.result_success)
+
+    def test_to_xapi_format(self):
+        """Test converting statement to xAPI JSON format."""
+        registration = uuid.uuid4()
+        statement = XAPIStatement.objects.create(
+            actor_user=self.user,
+            actor_mbox=self.user.email,
+            actor_name=self.user.username,
+            verb_id=XAPIVerb.COMPLETED,
+            verb_display='completed',
+            object_id='https://linguapal.com/quiz/gana_quiz/1',
+            object_definition={
+                'type': XAPIActivityType.ASSESSMENT,
+                'name': {'ko': '가나 퀴즈 #1'}
+            },
+            result_completion=True,
+            result_score_scaled=0.8,
+            result_score_raw=8,
+            result_score_min=0,
+            result_score_max=10,
+            context_registration=registration,
+        )
+
+        xapi_json = statement.to_xapi_format()
+
+        self.assertEqual(xapi_json['id'], str(statement.id))
+        self.assertEqual(xapi_json['actor']['mbox'], f'mailto:{self.user.email}')
+        self.assertEqual(xapi_json['verb']['id'], XAPIVerb.COMPLETED)
+        self.assertEqual(xapi_json['result']['score']['scaled'], 0.8)
+        self.assertEqual(xapi_json['context']['registration'], str(registration))
+
+    def test_statement_without_result(self):
+        """Test creating statement without result."""
+        statement = XAPIStatement.objects.create(
+            actor_user=self.user,
+            actor_mbox=self.user.email,
+            actor_name=self.user.username,
+            verb_id=XAPIVerb.INITIALIZED,
+            verb_display='initialized',
+            object_id='https://linguapal.com/quiz/gana_quiz/1',
+            object_definition={
+                'type': XAPIActivityType.ASSESSMENT,
+            },
+        )
+
+        xapi_json = statement.to_xapi_format()
+        self.assertNotIn('result', xapi_json)
+
+
+class CMI5SessionModelTest(TestCase):
+    """Tests for CMI5Session model."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com',
+            password='testpass123',
+            username='testuser'
+        )
+
+    def test_create_session(self):
+        """Test creating a cmi5 session."""
+        session = CMI5Session.objects.create(
+            actor_user=self.user,
+            au_id='https://linguapal.com/au/gana_quiz/1',
+            au_type='gana_quiz',
+            au_object_id=1,
+        )
+
+        self.assertIsNotNone(session.id)
+        self.assertIsNotNone(session.registration)
+        self.assertEqual(session.state, CMI5Session.SessionState.LAUNCHED)
+        self.assertEqual(session.mastery_score, DEFAULT_MASTERY_SCORE)
+
+    def test_session_initialize(self):
+        """Test initializing a session."""
+        session = CMI5Session.objects.create(
+            actor_user=self.user,
+            au_id='https://linguapal.com/au/gana_quiz/1',
+            au_type='gana_quiz',
+        )
+
+        session.initialize()
+
+        self.assertEqual(session.state, CMI5Session.SessionState.INITIALIZED)
+        self.assertIsNotNone(session.initialized_at)
+
+    def test_session_terminate(self):
+        """Test terminating a session."""
+        session = CMI5Session.objects.create(
+            actor_user=self.user,
+            au_id='https://linguapal.com/au/gana_quiz/1',
+            au_type='gana_quiz',
+        )
+        session.initialize()
+
+        session.terminate(is_passed=True, is_completed=True, score=0.9)
+
+        self.assertEqual(session.state, CMI5Session.SessionState.TERMINATED)
+        self.assertIsNotNone(session.terminated_at)
+        self.assertTrue(session.is_passed)
+        self.assertTrue(session.is_completed)
+        self.assertEqual(session.score_scaled, 0.9)
+
+    def test_session_abandon(self):
+        """Test abandoning a session."""
+        session = CMI5Session.objects.create(
+            actor_user=self.user,
+            au_id='https://linguapal.com/au/gana_quiz/1',
+            au_type='gana_quiz',
+        )
+
+        session.abandon()
+
+        self.assertEqual(session.state, CMI5Session.SessionState.ABANDONED)
+        self.assertIsNotNone(session.terminated_at)
+
+
+class LRSCredentialModelTest(TestCase):
+    """Tests for LRSCredential model."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='admin@example.com',
+            password='adminpass123',
+            username='admin',
+            role='admin'
+        )
+
+    def test_generate_credentials(self):
+        """Test generating credentials."""
+        credential, secret = LRSCredential.generate_credentials(
+            name='Test Credential',
+            permissions=['read', 'write'],
+            created_by=self.user
+        )
+
+        self.assertIsNotNone(credential.id)
+        self.assertIsNotNone(credential.key)
+        self.assertIsNotNone(secret)
+        self.assertTrue(credential.is_active)
+        self.assertEqual(credential.permissions, ['read', 'write'])
+
+    def test_check_secret(self):
+        """Test verifying credential secret."""
+        credential, secret = LRSCredential.generate_credentials(
+            name='Test Credential',
+            created_by=self.user
+        )
+
+        self.assertTrue(credential.check_secret(secret))
+        self.assertFalse(credential.check_secret('wrong_secret'))
+
+    def test_has_permission(self):
+        """Test permission checking."""
+        credential, _ = LRSCredential.generate_credentials(
+            name='Read Only',
+            permissions=['read'],
+            created_by=self.user
+        )
+
+        self.assertTrue(credential.has_permission('read'))
+        self.assertFalse(credential.has_permission('write'))
+
+
+class StatementBuilderServiceTest(TestCase):
+    """Tests for StatementBuilder service."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com',
+            password='testpass123',
+            username='testuser'
+        )
+
+    def test_build_statement(self):
+        """Test building a statement with StatementBuilder."""
+        statement = (
+            StatementBuilder(self.user)
+            .verb(XAPIVerb.ANSWERED)
+            .object_activity(
+                'quiz/gana_quiz/1/question/1',
+                '문제 #1',
+                XAPIActivityType.QUESTION
+            )
+            .result(success=True, response='a')
+            .context(quiz_type='gana_to_romaji')
+            .build()
+        )
+
+        self.assertIsNotNone(statement.id)
+        self.assertEqual(statement.verb_id, XAPIVerb.ANSWERED)
+        self.assertTrue(statement.result_success)
+        self.assertEqual(statement.result_response, 'a')
+        self.assertEqual(statement.context_extensions.get('quiz_type'), 'gana_to_romaji')
+
+    def test_build_without_verb_raises_error(self):
+        """Test that building without verb raises error."""
+        builder = (
+            StatementBuilder(self.user)
+            .object_activity('quiz/1', 'Quiz')
+        )
+
+        with self.assertRaises(ValueError):
+            builder.build()
+
+    def test_build_without_object_raises_error(self):
+        """Test that building without object raises error."""
+        builder = StatementBuilder(self.user).verb(XAPIVerb.ANSWERED)
+
+        with self.assertRaises(ValueError):
+            builder.build()
+
+    def test_create_from_data(self):
+        """Test creating statement from dictionary data."""
+        data = {
+            'actor_user_id': self.user.id,
+            'verb': 'answered',
+            'object_id': 'quiz/gana_quiz/1/question/1',
+            'object_name': '문제 #1',
+            'object_type': XAPIActivityType.QUESTION,
+            'result': {
+                'success': True,
+                'response': 'a',
+            },
+            'context': {
+                'quiz_type': 'gana_to_romaji',
+            }
+        }
+
+        statement = StatementBuilder.create_from_data(data)
+
+        self.assertIsNotNone(statement.id)
+        self.assertEqual(statement.verb_id, XAPIVerb.ANSWERED)
+        self.assertTrue(statement.result_success)
+
+
+class DashboardAPITest(APITestCase):
+    """Tests for Dashboard API endpoints."""
+
+    def setUp(self):
+        self.admin_user = User.objects.create_user(
+            email='admin@example.com',
+            password='adminpass123',
+            username='admin',
+            role='admin'  # Sets is_staff and is_superuser via User.save()
+        )
+        self.regular_user = User.objects.create_user(
+            email='user@example.com',
+            password='userpass123',
+            username='regularuser'
+        )
+        self.client = APIClient()
+
+        # Create some test statements
+        for i in range(5):
+            XAPIStatement.objects.create(
+                actor_user=self.regular_user,
+                actor_mbox=self.regular_user.email,
+                actor_name=self.regular_user.username,
+                verb_id=XAPIVerb.ANSWERED,
+                verb_display='answered',
+                object_id=f'https://linguapal.com/quiz/gana_quiz/1/question/{i+1}',
+                object_definition={'type': XAPIActivityType.QUESTION},
+                result_success=i % 2 == 0,  # Alternate correct/incorrect
+            )
+
+        # Create a completed quiz statement
+        XAPIStatement.objects.create(
+            actor_user=self.regular_user,
+            actor_mbox=self.regular_user.email,
+            actor_name=self.regular_user.username,
+            verb_id=XAPIVerb.COMPLETED,
+            verb_display='completed',
+            object_id='https://linguapal.com/quiz/gana_quiz/1',
+            object_definition={'type': XAPIActivityType.ASSESSMENT},
+            result_completion=True,
+            result_score_scaled=0.6,
+        )
+
+    def test_dashboard_overview_requires_staff(self):
+        """Test that dashboard overview requires staff permission."""
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get('/api/v1/lrs/dashboard/overview')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_dashboard_overview_success(self):
+        """Test dashboard overview with admin user."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/v1/lrs/dashboard/overview')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('total_users', response.data)
+        self.assertIn('total_questions', response.data)
+        self.assertIn('overall_accuracy', response.data)
+
+    def test_dashboard_users_list(self):
+        """Test dashboard users endpoint."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/v1/lrs/dashboard/users')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+
+    def test_dashboard_trends(self):
+        """Test dashboard trends endpoint."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/v1/lrs/dashboard/trends?days=7')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+
+    def test_dashboard_realtime(self):
+        """Test dashboard realtime endpoint."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/v1/lrs/dashboard/realtime')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('stats_24h', response.data)
+
+
+class StatementListAPITest(APITestCase):
+    """Tests for Statement List API."""
+
+    def setUp(self):
+        self.admin_user = User.objects.create_user(
+            email='admin@example.com',
+            password='adminpass123',
+            username='admin',
+            role='admin'
+        )
+        self.user = User.objects.create_user(
+            email='user@example.com',
+            password='userpass123',
+            username='user'
+        )
+        self.client = APIClient()
+
+        # Create test statements
+        for i in range(15):
+            XAPIStatement.objects.create(
+                actor_user=self.user,
+                actor_mbox=self.user.email,
+                actor_name=self.user.username,
+                verb_id=XAPIVerb.ANSWERED if i % 2 == 0 else XAPIVerb.COMPLETED,
+                verb_display='answered' if i % 2 == 0 else 'completed',
+                object_id=f'https://linguapal.com/quiz/gana_quiz/{i+1}',
+                object_definition={'type': XAPIActivityType.ASSESSMENT},
+            )
+
+    def test_statement_list_paginated(self):
+        """Test statement list returns paginated results."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/v1/lrs/statements?page_size=5')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('results', response.data)
+        self.assertEqual(len(response.data['results']), 5)
+
+    def test_statement_list_filter_by_verb(self):
+        """Test filtering statements by verb."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get(f'/api/v1/lrs/statements?verb={XAPIVerb.ANSWERED}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for stmt in response.data['results']:
+            self.assertEqual(stmt['verb']['id'], XAPIVerb.ANSWERED)
+
+    def test_statement_list_filter_by_user(self):
+        """Test filtering statements by user."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get(f'/api/v1/lrs/statements?user_id={self.user.id}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for stmt in response.data['results']:
+            self.assertEqual(stmt['actor']['mbox'], f'mailto:{self.user.email}')
+
+
+class XAPIEndpointTest(APITestCase):
+    """Tests for xAPI LRS endpoints."""
+
+    def setUp(self):
+        self.admin_user = User.objects.create_user(
+            email='admin@example.com',
+            password='adminpass123',
+            username='admin',
+            role='admin'
+        )
+        self.client = APIClient()
+
+        # Create LRS credential
+        self.credential, self.secret = LRSCredential.generate_credentials(
+            name='Test LRS',
+            permissions=['read', 'write'],
+            created_by=self.admin_user
+        )
+
+    def test_about_endpoint(self):
+        """Test xAPI about endpoint."""
+        response = self.client.get('/api/v1/lrs/xapi/about')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('version', response.data)
+
+    def test_post_statement_without_auth(self):
+        """Test posting statement without authentication fails."""
+        statement_data = {
+            'actor': {
+                'mbox': 'mailto:test@example.com',
+                'name': 'Test User'
+            },
+            'verb': {
+                'id': XAPIVerb.ANSWERED,
+                'display': {'en-US': 'answered'}
+            },
+            'object': {
+                'id': 'https://linguapal.com/quiz/1',
+                'definition': {'type': XAPIActivityType.ASSESSMENT}
+            }
+        }
+
+        response = self.client.post(
+            '/api/v1/lrs/xapi/statements',
+            statement_data,
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class LRSCredentialAPITest(APITestCase):
+    """Tests for LRS Credential API."""
+
+    def setUp(self):
+        self.admin_user = User.objects.create_user(
+            email='admin@example.com',
+            password='adminpass123',
+            username='admin',
+            role='admin'
+        )
+        self.regular_user = User.objects.create_user(
+            email='user@example.com',
+            password='userpass123',
+            username='user'
+        )
+        self.client = APIClient()
+
+    def test_create_credential_requires_admin(self):
+        """Test that creating credentials requires admin."""
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.post(
+            '/api/v1/lrs/credentials/',
+            {'name': 'Test Credential'},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_credential_success(self):
+        """Test creating credential as admin."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(
+            '/api/v1/lrs/credentials/',
+            {'name': 'Test Credential', 'permissions': ['read', 'write']},
+            format='json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('key', response.data)
+        self.assertIn('secret', response.data)
+        self.assertIn('message', response.data)
+
+    def test_list_credentials(self):
+        """Test listing credentials."""
+        # Create some credentials
+        LRSCredential.generate_credentials('Cred 1', created_by=self.admin_user)
+        LRSCredential.generate_credentials('Cred 2', created_by=self.admin_user)
+
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get('/api/v1/lrs/credentials/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_delete_credential_deactivates(self):
+        """Test that deleting a credential deactivates it."""
+        credential, _ = LRSCredential.generate_credentials(
+            'To Delete',
+            created_by=self.admin_user
+        )
+
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.delete(f'/api/v1/lrs/credentials/{credential.id}/')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Verify it's deactivated, not deleted
+        credential.refresh_from_db()
+        self.assertFalse(credential.is_active)
+
+
+class CMI5SessionAPITest(APITestCase):
+    """Tests for cmi5 Session API."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='test@example.com',
+            password='testpass123',
+            username='testuser'
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_start_session(self):
+        """Test starting a cmi5 session."""
+        response = self.client.post(
+            '/api/v1/lrs/cmi5/session/start',
+            {
+                'au_type': 'gana_quiz',
+                'au_object_id': 1,
+            },
+            format='json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('id', response.data)
+        self.assertIn('registration', response.data)
+        self.assertEqual(response.data['state'], 'launched')
+
+    def test_initialize_session(self):
+        """Test initializing a cmi5 session."""
+        # First create a session
+        session = CMI5Session.objects.create(
+            actor_user=self.user,
+            au_id='https://linguapal.com/au/gana_quiz/1',
+            au_type='gana_quiz',
+        )
+
+        response = self.client.post(
+            f'/api/v1/lrs/cmi5/session/{session.id}/initialize'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['state'], 'initialized')
+
+    def test_terminate_session(self):
+        """Test terminating a cmi5 session."""
+        session = CMI5Session.objects.create(
+            actor_user=self.user,
+            au_id='https://linguapal.com/au/gana_quiz/1',
+            au_type='gana_quiz',
+        )
+        session.initialize()
+
+        response = self.client.post(
+            f'/api/v1/lrs/cmi5/session/{session.id}/terminate',
+            {'score': 0.85, 'is_completed': True},
+            format='json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['state'], 'terminated')
+        self.assertTrue(response.data['is_passed'])

--- a/LinguaPal/lrs/urls.py
+++ b/LinguaPal/lrs/urls.py
@@ -1,0 +1,91 @@
+"""
+LRS URL Configuration
+
+URL patterns for:
+- xAPI LRS standard endpoints
+- cmi5 Launch and Session management
+- Admin Dashboard analytics
+- LRS Credential management
+"""
+
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+
+from .views import (
+    # xAPI
+    StatementView,
+    AboutView,
+    # cmi5
+    CMI5LaunchView,
+    CMI5SessionView,
+    CMI5AuthTokenView,
+    # Dashboard
+    DashboardOverviewView,
+    DashboardUsersView,
+    DashboardTrendsView,
+    DashboardRealtimeView,
+    StatementListView,
+    LRSCredentialViewSet,
+)
+
+app_name = 'lrs'
+
+# Router for ViewSets
+router = DefaultRouter()
+router.register(r'credentials', LRSCredentialViewSet, basename='credentials')
+
+# xAPI standard endpoints (nested under /xapi/)
+xapi_patterns = [
+    path('statements', StatementView.as_view(), name='xapi-statements'),
+    path('statements/', StatementView.as_view(), name='xapi-statements-slash'),
+    path('about', AboutView.as_view(), name='xapi-about'),
+    path('about/', AboutView.as_view(), name='xapi-about-slash'),
+]
+
+# cmi5 endpoints (nested under /cmi5/)
+cmi5_patterns = [
+    path('launch', CMI5LaunchView.as_view(), name='cmi5-launch'),
+    path('launch/', CMI5LaunchView.as_view(), name='cmi5-launch-slash'),
+    path('auth-token', CMI5AuthTokenView.as_view(), name='cmi5-auth-token'),
+    path('auth-token/', CMI5AuthTokenView.as_view(), name='cmi5-auth-token-slash'),
+    path('session/start', CMI5SessionView.as_view(), {'action': 'start'}, name='cmi5-session-start'),
+    path('session/start/', CMI5SessionView.as_view(), {'action': 'start'}, name='cmi5-session-start-slash'),
+    path('session/<uuid:session_id>', CMI5SessionView.as_view(), name='cmi5-session-detail'),
+    path('session/<uuid:session_id>/', CMI5SessionView.as_view(), name='cmi5-session-detail-slash'),
+    path('session/<uuid:session_id>/initialize', CMI5SessionView.as_view(), {'action': 'initialize'}, name='cmi5-session-initialize'),
+    path('session/<uuid:session_id>/initialize/', CMI5SessionView.as_view(), {'action': 'initialize'}, name='cmi5-session-initialize-slash'),
+    path('session/<uuid:session_id>/terminate', CMI5SessionView.as_view(), {'action': 'terminate'}, name='cmi5-session-terminate'),
+    path('session/<uuid:session_id>/terminate/', CMI5SessionView.as_view(), {'action': 'terminate'}, name='cmi5-session-terminate-slash'),
+    path('session/<uuid:session_id>/abandon', CMI5SessionView.as_view(), {'action': 'abandon'}, name='cmi5-session-abandon'),
+    path('session/<uuid:session_id>/abandon/', CMI5SessionView.as_view(), {'action': 'abandon'}, name='cmi5-session-abandon-slash'),
+]
+
+# Dashboard endpoints (nested under /dashboard/)
+dashboard_patterns = [
+    path('overview', DashboardOverviewView.as_view(), name='dashboard-overview'),
+    path('overview/', DashboardOverviewView.as_view(), name='dashboard-overview-slash'),
+    path('users', DashboardUsersView.as_view(), name='dashboard-users'),
+    path('users/', DashboardUsersView.as_view(), name='dashboard-users-slash'),
+    path('trends', DashboardTrendsView.as_view(), name='dashboard-trends'),
+    path('trends/', DashboardTrendsView.as_view(), name='dashboard-trends-slash'),
+    path('realtime', DashboardRealtimeView.as_view(), name='dashboard-realtime'),
+    path('realtime/', DashboardRealtimeView.as_view(), name='dashboard-realtime-slash'),
+]
+
+urlpatterns = [
+    # xAPI LRS endpoints
+    path('xapi/', include(xapi_patterns)),
+
+    # cmi5 endpoints
+    path('cmi5/', include(cmi5_patterns)),
+
+    # Dashboard endpoints
+    path('dashboard/', include(dashboard_patterns)),
+
+    # Statement list (admin)
+    path('statements', StatementListView.as_view(), name='statement-list'),
+    path('statements/', StatementListView.as_view(), name='statement-list-slash'),
+
+    # Credential management (router)
+    path('', include(router.urls)),
+]

--- a/LinguaPal/lrs/views/__init__.py
+++ b/LinguaPal/lrs/views/__init__.py
@@ -1,0 +1,43 @@
+"""
+LRS Views Package
+
+Contains views for:
+- xAPI LRS standard endpoints (Statement API, About)
+- cmi5 Launch and Session management
+- Admin Dashboard analytics
+"""
+
+from .xapi import (
+    StatementView,
+    AboutView,
+)
+from .cmi5 import (
+    CMI5LaunchView,
+    CMI5SessionView,
+    CMI5AuthTokenView,
+)
+from .dashboard import (
+    DashboardOverviewView,
+    DashboardUsersView,
+    DashboardTrendsView,
+    DashboardRealtimeView,
+    StatementListView,
+    LRSCredentialViewSet,
+)
+
+__all__ = [
+    # xAPI
+    'StatementView',
+    'AboutView',
+    # cmi5
+    'CMI5LaunchView',
+    'CMI5SessionView',
+    'CMI5AuthTokenView',
+    # Dashboard
+    'DashboardOverviewView',
+    'DashboardUsersView',
+    'DashboardTrendsView',
+    'DashboardRealtimeView',
+    'StatementListView',
+    'LRSCredentialViewSet',
+]

--- a/LinguaPal/lrs/views/cmi5.py
+++ b/LinguaPal/lrs/views/cmi5.py
@@ -1,0 +1,435 @@
+"""
+cmi5 Views
+
+Endpoints for cmi5 Assignable Unit (AU) launch and session management.
+
+cmi5 is a profile for xAPI that provides a standardized way to launch
+content from an LMS and track learning experiences.
+
+Endpoints:
+- GET /cmi5/launch - Generate launch URL with parameters
+- POST /cmi5/session/start - Start a new cmi5 session
+- POST /cmi5/session/{id}/initialize - Initialize session (AU ready)
+- POST /cmi5/session/{id}/terminate - Terminate session with results
+- POST /cmi5/session/{id}/abandon - Abandon session
+"""
+
+import logging
+import uuid
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+
+from ..models import CMI5Session, XAPIStatement
+from ..serializers import CMI5SessionSerializer
+from ..services import CMI5SessionService, StatementBuilder
+from ..constants import CMI5Verb, XAPIActivityType, LINGUAPAL_BASE_IRI
+from ..tasks import index_statement_task, index_session_task
+
+logger = logging.getLogger(__name__)
+
+
+class CMI5LaunchView(APIView):
+    """
+    cmi5 Launch URL generator.
+
+    Generates a launch URL with all required cmi5 parameters for
+    starting an Assignable Unit.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        """
+        Generate cmi5 launch URL.
+
+        Query parameters:
+        - au_type: Type of AU (gana_quiz, word_quiz)
+        - au_object_id: Quiz ID (optional)
+        - return_url: URL to return after completion (optional)
+
+        Returns:
+        - launch_url: URL with cmi5 parameters
+        - registration: Session registration UUID
+        - session_id: CMI5Session ID
+        """
+        au_type = request.query_params.get('au_type')
+        if not au_type:
+            return Response(
+                {'error': 'au_type parameter required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        au_object_id = request.query_params.get('au_object_id')
+        if au_object_id:
+            au_object_id = int(au_object_id)
+
+        return_url = request.query_params.get('return_url', '')
+
+        # Create cmi5 session
+        session = CMI5SessionService.create_session(
+            user=request.user,
+            au_type=au_type,
+            au_object_id=au_object_id,
+        )
+
+        # Build launch URL with cmi5 parameters
+        base_url = getattr(settings, 'CMI5_AU_BASE_URL', f'{request.scheme}://{request.get_host()}')
+
+        # Determine AU endpoint based on type
+        au_endpoints = {
+            'gana_quiz': '/quiz/gana',
+            'word_quiz': '/quiz/word',
+        }
+        au_endpoint = au_endpoints.get(au_type, f'/quiz/{au_type}')
+
+        if au_object_id:
+            au_endpoint = f'{au_endpoint}/{au_object_id}'
+
+        # cmi5 launch parameters
+        params = {
+            'endpoint': f'{base_url}/api/v1/lrs/xapi/',
+            'fetch': f'{base_url}/api/v1/lrs/cmi5/auth-token',
+            'registration': str(session.registration),
+            'activityId': session.au_id,
+            'actor': f'{{"mbox":"mailto:{request.user.email}","name":"{request.user.username}"}}',
+        }
+
+        if return_url:
+            params['returnURL'] = return_url
+
+        launch_url = f'{base_url}{au_endpoint}?{urlencode(params)}'
+
+        # Create LAUNCHED statement
+        statement = StatementBuilder(request.user) \
+            .verb(CMI5Verb.LAUNCHED, 'launched') \
+            .object_activity(
+                session.au_id,
+                f'{au_type.replace("_", " ").title()}',
+                XAPIActivityType.ASSESSMENT
+            ) \
+            .context(registration=session.registration) \
+            .build()
+
+        # Queue ES indexing
+        try:
+            index_statement_task.delay(str(statement.id))
+            index_session_task.delay(str(session.id))
+        except Exception as exc:
+            logger.warning(f"Could not queue indexing: {exc}")
+
+        return Response({
+            'launch_url': launch_url,
+            'registration': str(session.registration),
+            'session_id': str(session.id),
+            'au_id': session.au_id,
+        })
+
+
+class CMI5SessionView(APIView):
+    """
+    cmi5 Session management.
+
+    Handles session lifecycle:
+    - start: Create new session (LAUNCHED)
+    - initialize: Mark session as initialized
+    - terminate: End session with results
+    - abandon: Abandon session without completion
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, session_id=None, action=None):
+        """
+        Handle session actions.
+
+        URL patterns:
+        - POST /cmi5/session/start - Start new session
+        - POST /cmi5/session/{id}/initialize - Initialize
+        - POST /cmi5/session/{id}/terminate - Terminate with results
+        - POST /cmi5/session/{id}/abandon - Abandon
+        """
+        if action == 'start' or (session_id is None and action is None):
+            return self._start_session(request)
+
+        if not session_id:
+            return Response(
+                {'error': 'session_id required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            session = CMI5Session.objects.get(
+                id=session_id,
+                actor_user=request.user
+            )
+        except CMI5Session.DoesNotExist:
+            return Response(
+                {'error': 'Session not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        if action == 'initialize':
+            return self._initialize_session(request, session)
+        elif action == 'terminate':
+            return self._terminate_session(request, session)
+        elif action == 'abandon':
+            return self._abandon_session(request, session)
+        else:
+            return Response(
+                {'error': f'Unknown action: {action}'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+    def get(self, request, session_id=None):
+        """Get session details."""
+        if session_id:
+            try:
+                session = CMI5Session.objects.get(
+                    id=session_id,
+                    actor_user=request.user
+                )
+                serializer = CMI5SessionSerializer(session)
+                return Response(serializer.data)
+            except CMI5Session.DoesNotExist:
+                return Response(
+                    {'error': 'Session not found'},
+                    status=status.HTTP_404_NOT_FOUND
+                )
+        else:
+            # List user's sessions
+            sessions = CMI5Session.objects.filter(
+                actor_user=request.user
+            ).order_by('-launched_at')[:20]
+            serializer = CMI5SessionSerializer(sessions, many=True)
+            return Response(serializer.data)
+
+    def _start_session(self, request):
+        """Start a new cmi5 session."""
+        au_type = request.data.get('au_type')
+        if not au_type:
+            return Response(
+                {'error': 'au_type required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        au_object_id = request.data.get('au_object_id')
+
+        # Check for existing active session
+        existing = CMI5SessionService.get_active_session(
+            request.user, au_type, au_object_id
+        )
+        if existing:
+            return Response({
+                'session_id': str(existing.id),
+                'registration': str(existing.registration),
+                'message': 'Existing active session found',
+            })
+
+        # Create new session
+        session = CMI5SessionService.create_session(
+            user=request.user,
+            au_type=au_type,
+            au_object_id=au_object_id,
+        )
+
+        # Create LAUNCHED statement
+        statement = StatementBuilder(request.user) \
+            .verb(CMI5Verb.LAUNCHED, 'launched') \
+            .object_activity(
+                session.au_id,
+                f'{au_type.replace("_", " ").title()}',
+                XAPIActivityType.ASSESSMENT
+            ) \
+            .context(registration=session.registration) \
+            .build()
+
+        # Queue indexing
+        try:
+            index_statement_task.delay(str(statement.id))
+            index_session_task.delay(str(session.id))
+        except Exception as exc:
+            logger.warning(f"Could not queue indexing: {exc}")
+
+        serializer = CMI5SessionSerializer(session)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def _initialize_session(self, request, session):
+        """Initialize a cmi5 session (AU is ready)."""
+        if session.state != CMI5Session.SessionState.LAUNCHED:
+            return Response(
+                {'error': f'Cannot initialize session in state: {session.state}'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Update session state
+        session.initialize()
+
+        # Create INITIALIZED statement
+        statement = StatementBuilder(request.user) \
+            .verb(CMI5Verb.INITIALIZED, 'initialized') \
+            .object_activity(
+                session.au_id,
+                f'{session.au_type.replace("_", " ").title()}',
+                XAPIActivityType.ASSESSMENT
+            ) \
+            .context(registration=session.registration) \
+            .build()
+
+        # Queue indexing
+        try:
+            index_statement_task.delay(str(statement.id))
+            index_session_task.delay(str(session.id))
+        except Exception as exc:
+            logger.warning(f"Could not queue indexing: {exc}")
+
+        serializer = CMI5SessionSerializer(session)
+        return Response(serializer.data)
+
+    def _terminate_session(self, request, session):
+        """Terminate a cmi5 session with results."""
+        if session.state not in [
+            CMI5Session.SessionState.LAUNCHED,
+            CMI5Session.SessionState.INITIALIZED
+        ]:
+            return Response(
+                {'error': f'Cannot terminate session in state: {session.state}'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Get results from request
+        is_passed = request.data.get('passed')
+        is_completed = request.data.get('completed', True)
+        score = request.data.get('score')
+
+        if score is not None:
+            score = float(score)
+
+        # Update session
+        session.terminate(
+            is_passed=is_passed,
+            is_completed=is_completed,
+            score=score,
+        )
+
+        # Create TERMINATED statement
+        result_kwargs = {}
+        if score is not None:
+            result_kwargs['score_scaled'] = score
+        if is_completed is not None:
+            result_kwargs['completion'] = is_completed
+        if is_passed is not None:
+            result_kwargs['success'] = is_passed
+
+        statement = StatementBuilder(request.user) \
+            .verb(CMI5Verb.TERMINATED, 'terminated') \
+            .object_activity(
+                session.au_id,
+                f'{session.au_type.replace("_", " ").title()}',
+                XAPIActivityType.ASSESSMENT
+            ) \
+            .result(**result_kwargs) \
+            .context(registration=session.registration) \
+            .build()
+
+        # Queue indexing
+        try:
+            index_statement_task.delay(str(statement.id))
+            index_session_task.delay(str(session.id))
+        except Exception as exc:
+            logger.warning(f"Could not queue indexing: {exc}")
+
+        serializer = CMI5SessionSerializer(session)
+        return Response(serializer.data)
+
+    def _abandon_session(self, request, session):
+        """Abandon a cmi5 session."""
+        if session.state == CMI5Session.SessionState.TERMINATED:
+            return Response(
+                {'error': 'Session already terminated'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if session.state == CMI5Session.SessionState.ABANDONED:
+            return Response(
+                {'error': 'Session already abandoned'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Update session state
+        session.abandon()
+
+        # Create ABANDONED statement
+        statement = StatementBuilder(request.user) \
+            .verb(CMI5Verb.ABANDONED, 'abandoned') \
+            .object_activity(
+                session.au_id,
+                f'{session.au_type.replace("_", " ").title()}',
+                XAPIActivityType.ASSESSMENT
+            ) \
+            .context(registration=session.registration) \
+            .build()
+
+        # Queue indexing
+        try:
+            index_statement_task.delay(str(statement.id))
+            index_session_task.delay(str(session.id))
+        except Exception as exc:
+            logger.warning(f"Could not queue indexing: {exc}")
+
+        serializer = CMI5SessionSerializer(session)
+        return Response(serializer.data)
+
+
+class CMI5AuthTokenView(APIView):
+    """
+    cmi5 Auth Token endpoint.
+
+    Called by AU to retrieve authentication token for xAPI communication.
+    This is the 'fetch' URL in cmi5 launch parameters.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        """
+        Issue auth token for cmi5 AU.
+
+        The AU calls this endpoint with the fetch URL to get credentials
+        for making xAPI requests.
+        """
+        registration = request.data.get('registration')
+        if not registration:
+            return Response(
+                {'error': 'registration required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            session = CMI5Session.objects.get(
+                registration=registration,
+                actor_user=request.user
+            )
+        except CMI5Session.DoesNotExist:
+            return Response(
+                {'error': 'Session not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # For cmi5, we typically use OAuth tokens, but since we're using
+        # session-based auth, we'll return the necessary info for the AU
+        # to make authenticated requests
+
+        # In a production environment, you might want to generate
+        # a short-lived token here
+        return Response({
+            'auth-token': request.auth.key if hasattr(request, 'auth') and request.auth else None,
+            'registration': str(session.registration),
+            'session_id': str(session.id),
+            'endpoint': f'{request.scheme}://{request.get_host()}/api/v1/lrs/xapi/',
+        })

--- a/LinguaPal/lrs/views/dashboard.py
+++ b/LinguaPal/lrs/views/dashboard.py
@@ -1,0 +1,515 @@
+"""
+LRS Dashboard Views
+
+Admin Dashboard APIs for learning analytics and statistics.
+
+All endpoints require staff/admin authentication (IsStaffRole).
+
+Endpoints:
+- GET /dashboard/overview - Basic statistics
+- GET /dashboard/users - User-specific stats
+- GET /dashboard/trends - Time-based trends
+- GET /dashboard/realtime - Real-time activity
+- GET /statements - Statement list with filtering
+- CRUD /credentials - LRS Credential management
+"""
+
+import logging
+from datetime import timedelta
+
+from django.db.models import Count, Avg, Q, F
+from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
+from django.utils import timezone
+from rest_framework import status, viewsets
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.pagination import PageNumberPagination
+
+from accounts.models import User
+from ..models import XAPIStatement, CMI5Session, LRSCredential
+from ..serializers import (
+    XAPIStatementSerializer,
+    CMI5SessionSerializer,
+    LRSCredentialSerializer,
+    LRSCredentialCreateSerializer,
+    DashboardOverviewSerializer,
+    DashboardUserStatsSerializer,
+    DashboardTrendSerializer,
+)
+from ..constants import XAPIVerb, QuizType
+from ..elasticsearch import get_client, STATEMENT_INDEX, search_statements
+
+logger = logging.getLogger(__name__)
+
+
+class IsStaffOrAdmin(IsAuthenticated):
+    """Permission class for staff/admin users."""
+
+    def has_permission(self, request, view):
+        if not super().has_permission(request, view):
+            return False
+        return request.user.is_staff or request.user.is_superuser
+
+
+class StatementPagination(PageNumberPagination):
+    """Pagination for statement list."""
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+
+class DashboardOverviewView(APIView):
+    """
+    Dashboard overview with basic statistics.
+
+    Returns:
+    - total_users: Total registered users
+    - active_users: Users with activity in last 30 days
+    - total_quizzes: Total completed quizzes
+    - completed_quizzes: Successfully completed quizzes
+    - total_questions: Total questions answered
+    - total_correct: Total correct answers
+    - overall_accuracy: Overall accuracy percentage
+    - pass_rate: Quiz pass rate percentage
+    - quiz_type_breakdown: Stats by quiz type
+    """
+
+    permission_classes = [IsStaffOrAdmin]
+
+    def get(self, request):
+        """Get dashboard overview statistics."""
+        now = timezone.now()
+        thirty_days_ago = now - timedelta(days=30)
+
+        # User statistics
+        total_users = User.objects.count()
+        active_users = XAPIStatement.objects.filter(
+            timestamp__gte=thirty_days_ago
+        ).values('actor_user').distinct().count()
+
+        # Quiz statistics (from COMPLETED statements)
+        completed_stmt = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.COMPLETED
+        )
+        total_quizzes = completed_stmt.count()
+
+        # Pass/fail statistics
+        passed_count = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.PASSED
+        ).count()
+        failed_count = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.FAILED
+        ).count()
+
+        # Question statistics (from ANSWERED statements)
+        answered_stmt = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.ANSWERED
+        )
+        total_questions = answered_stmt.count()
+        total_correct = answered_stmt.filter(result_success=True).count()
+
+        # Calculate rates
+        overall_accuracy = (total_correct / total_questions * 100) if total_questions > 0 else 0
+        pass_rate = (passed_count / (passed_count + failed_count) * 100) if (passed_count + failed_count) > 0 else 0
+
+        # Quiz type breakdown
+        quiz_type_breakdown = {}
+        for quiz_type in [QuizType.GANA_QUIZ, QuizType.WORD_QUIZ]:
+            type_completed = completed_stmt.filter(
+                object_id__icontains=quiz_type
+            ).count()
+            type_passed = XAPIStatement.objects.filter(
+                verb_id=XAPIVerb.PASSED,
+                object_id__icontains=quiz_type
+            ).count()
+            type_questions = answered_stmt.filter(
+                object_id__icontains=quiz_type
+            ).count()
+            type_correct = answered_stmt.filter(
+                object_id__icontains=quiz_type,
+                result_success=True
+            ).count()
+
+            quiz_type_breakdown[quiz_type] = {
+                'completed': type_completed,
+                'passed': type_passed,
+                'questions': type_questions,
+                'correct': type_correct,
+                'accuracy': (type_correct / type_questions * 100) if type_questions > 0 else 0,
+            }
+
+        data = {
+            'total_users': total_users,
+            'active_users': active_users,
+            'total_quizzes': total_quizzes,
+            'completed_quizzes': passed_count + failed_count,
+            'total_questions': total_questions,
+            'total_correct': total_correct,
+            'overall_accuracy': round(overall_accuracy, 2),
+            'pass_rate': round(pass_rate, 2),
+            'quiz_type_breakdown': quiz_type_breakdown,
+        }
+
+        serializer = DashboardOverviewSerializer(data)
+        return Response(serializer.data)
+
+
+class DashboardUsersView(APIView):
+    """
+    User-specific statistics and rankings.
+
+    Query parameters:
+    - sort: Sort field (quizzes, accuracy, last_activity) default: quizzes
+    - order: asc or desc (default: desc)
+    - limit: Number of users (default: 20)
+    """
+
+    permission_classes = [IsStaffOrAdmin]
+
+    def get(self, request):
+        """Get per-user statistics."""
+        sort_field = request.query_params.get('sort', 'quizzes')
+        order = request.query_params.get('order', 'desc')
+        limit = int(request.query_params.get('limit', 20))
+
+        # Get users with quiz activity
+        users_with_activity = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.COMPLETED
+        ).values('actor_user').annotate(
+            total_quizzes=Count('id')
+        ).values_list('actor_user', flat=True)
+
+        user_stats = []
+        for user_id in users_with_activity[:100]:  # Limit to 100 for performance
+            try:
+                user = User.objects.get(pk=user_id)
+            except User.DoesNotExist:
+                continue
+
+            # Get user's answered statements
+            user_answered = XAPIStatement.objects.filter(
+                actor_user=user,
+                verb_id=XAPIVerb.ANSWERED
+            )
+            total_questions = user_answered.count()
+            total_correct = user_answered.filter(result_success=True).count()
+
+            # Get user's completed quizzes
+            total_quizzes = XAPIStatement.objects.filter(
+                actor_user=user,
+                verb_id=XAPIVerb.COMPLETED
+            ).count()
+
+            # Get last activity
+            last_stmt = XAPIStatement.objects.filter(
+                actor_user=user
+            ).order_by('-timestamp').first()
+
+            user_stats.append({
+                'user_id': user.id,
+                'email': user.email,
+                'username': user.username or user.email,
+                'total_quizzes': total_quizzes,
+                'total_correct': total_correct,
+                'total_questions': total_questions,
+                'accuracy': round((total_correct / total_questions * 100), 2) if total_questions > 0 else 0,
+                'last_activity': last_stmt.timestamp if last_stmt else None,
+            })
+
+        # Sort results
+        sort_key = {
+            'quizzes': 'total_quizzes',
+            'accuracy': 'accuracy',
+            'last_activity': 'last_activity',
+            'questions': 'total_questions',
+        }.get(sort_field, 'total_quizzes')
+
+        reverse = order == 'desc'
+        user_stats.sort(
+            key=lambda x: (x[sort_key] is not None, x[sort_key]),
+            reverse=reverse
+        )
+
+        serializer = DashboardUserStatsSerializer(user_stats[:limit], many=True)
+        return Response(serializer.data)
+
+
+class DashboardTrendsView(APIView):
+    """
+    Time-based learning trends.
+
+    Query parameters:
+    - period: day, week, or month (default: day)
+    - days: Number of days to include (default: 30)
+    """
+
+    permission_classes = [IsStaffOrAdmin]
+
+    def get(self, request):
+        """Get time-based trends."""
+        period = request.query_params.get('period', 'day')
+        days = int(request.query_params.get('days', 30))
+
+        start_date = timezone.now() - timedelta(days=days)
+
+        # Select truncation function based on period
+        if period == 'week':
+            trunc_func = TruncWeek('timestamp')
+        elif period == 'month':
+            trunc_func = TruncMonth('timestamp')
+        else:
+            trunc_func = TruncDate('timestamp')
+
+        # Get quiz completion trends
+        completion_trends = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.COMPLETED,
+            timestamp__gte=start_date
+        ).annotate(
+            date=trunc_func
+        ).values('date').annotate(
+            quizzes_completed=Count('id')
+        ).order_by('date')
+
+        # Get question answer trends
+        answer_trends = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.ANSWERED,
+            timestamp__gte=start_date
+        ).annotate(
+            date=trunc_func
+        ).values('date').annotate(
+            questions_answered=Count('id'),
+            correct_answers=Count('id', filter=Q(result_success=True))
+        ).order_by('date')
+
+        # Get unique user trends
+        user_trends = XAPIStatement.objects.filter(
+            timestamp__gte=start_date
+        ).annotate(
+            date=trunc_func
+        ).values('date').annotate(
+            unique_users=Count('actor_user', distinct=True)
+        ).order_by('date')
+
+        # Merge trends data
+        trends_dict = {}
+        for item in completion_trends:
+            date_key = item['date']
+            if date_key not in trends_dict:
+                trends_dict[date_key] = {
+                    'date': date_key,
+                    'quizzes_completed': 0,
+                    'questions_answered': 0,
+                    'correct_answers': 0,
+                    'unique_users': 0,
+                }
+            trends_dict[date_key]['quizzes_completed'] = item['quizzes_completed']
+
+        for item in answer_trends:
+            date_key = item['date']
+            if date_key not in trends_dict:
+                trends_dict[date_key] = {
+                    'date': date_key,
+                    'quizzes_completed': 0,
+                    'questions_answered': 0,
+                    'correct_answers': 0,
+                    'unique_users': 0,
+                }
+            trends_dict[date_key]['questions_answered'] = item['questions_answered']
+            trends_dict[date_key]['correct_answers'] = item['correct_answers']
+
+        for item in user_trends:
+            date_key = item['date']
+            if date_key in trends_dict:
+                trends_dict[date_key]['unique_users'] = item['unique_users']
+
+        # Sort by date
+        trends = sorted(trends_dict.values(), key=lambda x: x['date'])
+
+        serializer = DashboardTrendSerializer(trends, many=True)
+        return Response(serializer.data)
+
+
+class DashboardRealtimeView(APIView):
+    """
+    Real-time activity dashboard.
+
+    Returns:
+    - active_sessions: Currently active cmi5 sessions
+    - recent_completions: Recently completed quizzes
+    - recent_activity: Recent xAPI statements
+    - stats_24h: Statistics for last 24 hours
+    """
+
+    permission_classes = [IsStaffOrAdmin]
+
+    def get(self, request):
+        """Get real-time activity data."""
+        now = timezone.now()
+        twenty_four_hours_ago = now - timedelta(hours=24)
+        one_hour_ago = now - timedelta(hours=1)
+
+        # Active cmi5 sessions
+        active_sessions = CMI5Session.objects.filter(
+            state__in=[
+                CMI5Session.SessionState.LAUNCHED,
+                CMI5Session.SessionState.INITIALIZED
+            ],
+            launched_at__gte=twenty_four_hours_ago
+        ).count()
+
+        # Recently completed quizzes (last hour)
+        recent_completions = XAPIStatement.objects.filter(
+            verb_id=XAPIVerb.COMPLETED,
+            timestamp__gte=one_hour_ago
+        ).select_related('actor_user').order_by('-timestamp')[:10]
+
+        # Recent activity (last hour)
+        recent_activity = XAPIStatement.objects.filter(
+            timestamp__gte=one_hour_ago
+        ).select_related('actor_user').order_by('-timestamp')[:20]
+
+        # 24-hour statistics
+        stats_24h = {
+            'quizzes_started': XAPIStatement.objects.filter(
+                verb_id=XAPIVerb.INITIALIZED,
+                timestamp__gte=twenty_four_hours_ago
+            ).count(),
+            'quizzes_completed': XAPIStatement.objects.filter(
+                verb_id=XAPIVerb.COMPLETED,
+                timestamp__gte=twenty_four_hours_ago
+            ).count(),
+            'questions_answered': XAPIStatement.objects.filter(
+                verb_id=XAPIVerb.ANSWERED,
+                timestamp__gte=twenty_four_hours_ago
+            ).count(),
+            'unique_users': XAPIStatement.objects.filter(
+                timestamp__gte=twenty_four_hours_ago
+            ).values('actor_user').distinct().count(),
+            'passed': XAPIStatement.objects.filter(
+                verb_id=XAPIVerb.PASSED,
+                timestamp__gte=twenty_four_hours_ago
+            ).count(),
+            'failed': XAPIStatement.objects.filter(
+                verb_id=XAPIVerb.FAILED,
+                timestamp__gte=twenty_four_hours_ago
+            ).count(),
+        }
+
+        return Response({
+            'active_sessions': active_sessions,
+            'recent_completions': XAPIStatementSerializer(recent_completions, many=True).data,
+            'recent_activity': XAPIStatementSerializer(recent_activity, many=True).data,
+            'stats_24h': stats_24h,
+        })
+
+
+class StatementListView(APIView):
+    """
+    Statement list with filtering and pagination.
+
+    Query parameters:
+    - user_id: Filter by user
+    - verb: Filter by verb ID
+    - activity: Filter by object ID
+    - since: Filter by timestamp (ISO format)
+    - until: Filter by timestamp (ISO format)
+    - page: Page number
+    - page_size: Results per page (max 200)
+    """
+
+    permission_classes = [IsStaffOrAdmin]
+    pagination_class = StatementPagination
+
+    def get(self, request):
+        """Get filtered statement list."""
+        queryset = XAPIStatement.objects.all()
+
+        # Apply filters
+        user_id = request.query_params.get('user_id')
+        if user_id:
+            queryset = queryset.filter(actor_user_id=user_id)
+
+        verb = request.query_params.get('verb')
+        if verb:
+            queryset = queryset.filter(verb_id=verb)
+
+        activity = request.query_params.get('activity')
+        if activity:
+            queryset = queryset.filter(object_id__icontains=activity)
+
+        since = request.query_params.get('since')
+        if since:
+            queryset = queryset.filter(timestamp__gte=since)
+
+        until = request.query_params.get('until')
+        if until:
+            queryset = queryset.filter(timestamp__lte=until)
+
+        # Order by timestamp descending
+        queryset = queryset.order_by('-timestamp')
+
+        # Paginate
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(queryset, request)
+
+        if page is not None:
+            serializer = XAPIStatementSerializer(page, many=True)
+            return paginator.get_paginated_response(serializer.data)
+
+        serializer = XAPIStatementSerializer(queryset[:100], many=True)
+        return Response(serializer.data)
+
+
+class LRSCredentialViewSet(viewsets.ModelViewSet):
+    """
+    LRS Credential management.
+
+    Admin-only CRUD operations for managing LRS API credentials.
+    """
+
+    permission_classes = [IsAdminUser]
+    serializer_class = LRSCredentialSerializer
+    queryset = LRSCredential.objects.all()
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return LRSCredentialCreateSerializer
+        return LRSCredentialSerializer
+
+    def create(self, request, *args, **kwargs):
+        """Create a new LRS credential."""
+        serializer = LRSCredentialCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        name = serializer.validated_data['name']
+        permissions = serializer.validated_data.get('permissions', ['read', 'write'])
+
+        # Generate credential
+        credential, secret = LRSCredential.generate_credentials(
+            name=name,
+            permissions=permissions,
+            created_by=request.user,
+        )
+
+        # Return credential with plain secret (only time it's available)
+        return Response({
+            'id': str(credential.id),
+            'name': credential.name,
+            'key': credential.key,
+            'secret': secret,  # Only returned on creation!
+            'permissions': credential.permissions,
+            'created_at': credential.created_at,
+            'message': 'Save the secret now - it cannot be retrieved later!',
+        }, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, *args, **kwargs):
+        """Deactivate a credential instead of deleting."""
+        instance = self.get_object()
+        instance.is_active = False
+        instance.save(update_fields=['is_active'])
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/LinguaPal/lrs/views/xapi.py
+++ b/LinguaPal/lrs/views/xapi.py
@@ -1,0 +1,381 @@
+"""
+xAPI LRS Views
+
+Standard xAPI LRS endpoints following the xAPI 1.0.3 specification.
+
+Endpoints:
+- GET/POST/PUT /xapi/statements - Statement Resource
+- GET /xapi/about - About Resource
+"""
+
+import logging
+import uuid
+
+from django.conf import settings
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+
+from ..models import XAPIStatement
+from ..serializers import (
+    XAPIStatementSerializer,
+    XAPIStatementInputSerializer,
+    StatementQuerySerializer,
+    LRSAboutSerializer,
+)
+from ..authentication import (
+    LRSBasicAuthentication,
+    HasLRSReadPermission,
+    HasLRSWritePermission,
+)
+from ..services import StatementBuilder
+from ..tasks import index_statement_task
+
+logger = logging.getLogger(__name__)
+
+# xAPI version supported
+XAPI_VERSION = '1.0.3'
+
+
+class StatementView(APIView):
+    """
+    xAPI Statement Resource.
+
+    Supports:
+    - GET: Retrieve statement(s)
+    - POST: Store statement(s)
+    - PUT: Store a single statement with specified ID
+    """
+
+    authentication_classes = [LRSBasicAuthentication]
+
+    def get_permissions(self):
+        """Return appropriate permissions based on HTTP method."""
+        if self.request.method == 'GET':
+            return [HasLRSReadPermission()]
+        return [HasLRSWritePermission()]
+
+    def get(self, request):
+        """
+        Retrieve xAPI statement(s).
+
+        Query parameters (xAPI standard):
+        - statementId: Fetch specific statement
+        - agent: Filter by actor
+        - verb: Filter by verb IRI
+        - activity: Filter by object ID
+        - registration: Filter by registration UUID
+        - since: Return statements stored after this timestamp
+        - until: Return statements stored before this timestamp
+        - limit: Maximum number of statements (default 100)
+        - ascending: Sort order (default False = descending)
+        """
+        # Validate X-Experience-API-Version header
+        api_version = request.META.get('HTTP_X_EXPERIENCE_API_VERSION')
+        if api_version and not api_version.startswith('1.'):
+            return Response(
+                {'error': f'Unsupported xAPI version: {api_version}'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Parse query parameters
+        query_serializer = StatementQuerySerializer(data=request.query_params)
+        if not query_serializer.is_valid():
+            return Response(
+                query_serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        params = query_serializer.validated_data
+
+        # Single statement lookup
+        statement_id = params.get('statementId')
+        if statement_id:
+            try:
+                statement = XAPIStatement.objects.get(id=statement_id)
+                serializer = XAPIStatementSerializer(statement)
+                return Response(serializer.data)
+            except XAPIStatement.DoesNotExist:
+                return Response(
+                    {'error': 'Statement not found'},
+                    status=status.HTTP_404_NOT_FOUND
+                )
+
+        # Build queryset with filters
+        queryset = XAPIStatement.objects.all()
+
+        # Filter by agent (actor mbox)
+        agent = params.get('agent')
+        if agent:
+            # Agent can be JSON or mbox string
+            if agent.startswith('mailto:'):
+                queryset = queryset.filter(actor_mbox=agent.replace('mailto:', ''))
+            else:
+                queryset = queryset.filter(actor_mbox__icontains=agent)
+
+        # Filter by verb
+        verb = params.get('verb')
+        if verb:
+            queryset = queryset.filter(verb_id=verb)
+
+        # Filter by activity (object)
+        activity = params.get('activity')
+        if activity:
+            queryset = queryset.filter(object_id=activity)
+
+        # Filter by registration
+        registration = params.get('registration')
+        if registration:
+            queryset = queryset.filter(context_registration=registration)
+
+        # Filter by time range
+        since = params.get('since')
+        if since:
+            queryset = queryset.filter(stored__gt=since)
+
+        until = params.get('until')
+        if until:
+            queryset = queryset.filter(stored__lte=until)
+
+        # Sorting
+        ascending = params.get('ascending', False)
+        if ascending:
+            queryset = queryset.order_by('stored')
+        else:
+            queryset = queryset.order_by('-stored')
+
+        # Limit results
+        limit = params.get('limit', 100)
+        queryset = queryset[:limit]
+
+        # Serialize and return
+        serializer = XAPIStatementSerializer(queryset, many=True)
+
+        response_data = {
+            'statements': serializer.data,
+        }
+
+        response = Response(response_data)
+        response['X-Experience-API-Version'] = XAPI_VERSION
+        return response
+
+    def post(self, request):
+        """
+        Store xAPI statement(s).
+
+        Accepts single statement or array of statements.
+        Returns array of statement IDs.
+        """
+        # Validate X-Experience-API-Version header
+        api_version = request.META.get('HTTP_X_EXPERIENCE_API_VERSION')
+        if not api_version:
+            return Response(
+                {'error': 'X-Experience-API-Version header required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        data = request.data
+        is_array = isinstance(data, list)
+        statements_data = data if is_array else [data]
+
+        statement_ids = []
+
+        for stmt_data in statements_data:
+            # Validate input
+            serializer = XAPIStatementInputSerializer(data=stmt_data)
+            if not serializer.is_valid():
+                return Response(
+                    serializer.errors,
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            validated_data = serializer.validated_data
+
+            try:
+                # Create statement
+                statement = self._create_statement(validated_data, request.auth)
+                statement_ids.append(str(statement.id))
+
+                # Queue ES indexing
+                try:
+                    index_statement_task.delay(str(statement.id))
+                except Exception as exc:
+                    logger.warning(f"Could not queue ES indexing: {exc}")
+
+            except Exception as exc:
+                logger.error(f"Error creating statement: {exc}")
+                return Response(
+                    {'error': str(exc)},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+        response = Response(statement_ids, status=status.HTTP_200_OK)
+        response['X-Experience-API-Version'] = XAPI_VERSION
+        return response
+
+    def put(self, request):
+        """
+        Store a single xAPI statement with specified ID.
+
+        Query parameter:
+        - statementId: Required UUID for the statement
+        """
+        statement_id = request.query_params.get('statementId')
+        if not statement_id:
+            return Response(
+                {'error': 'statementId query parameter required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            statement_uuid = uuid.UUID(statement_id)
+        except ValueError:
+            return Response(
+                {'error': 'Invalid statementId format'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Check if statement already exists
+        if XAPIStatement.objects.filter(id=statement_uuid).exists():
+            return Response(
+                {'error': 'Statement with this ID already exists'},
+                status=status.HTTP_409_CONFLICT
+            )
+
+        # Validate input
+        serializer = XAPIStatementInputSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        validated_data = serializer.validated_data
+        validated_data['id'] = statement_uuid
+
+        try:
+            statement = self._create_statement(validated_data, request.auth)
+
+            # Queue ES indexing
+            try:
+                index_statement_task.delay(str(statement.id))
+            except Exception as exc:
+                logger.warning(f"Could not queue ES indexing: {exc}")
+
+            response = Response(status=status.HTTP_204_NO_CONTENT)
+            response['X-Experience-API-Version'] = XAPI_VERSION
+            return response
+
+        except Exception as exc:
+            logger.error(f"Error creating statement: {exc}")
+            return Response(
+                {'error': str(exc)},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+    def _create_statement(self, validated_data, credential):
+        """
+        Create an XAPIStatement from validated data.
+
+        Args:
+            validated_data: Validated statement data dict
+            credential: LRSCredential used for authentication
+
+        Returns:
+            Created XAPIStatement instance
+        """
+        actor = validated_data['actor']
+        verb = validated_data['verb']
+        obj = validated_data['object']
+        result = validated_data.get('result', {})
+        context = validated_data.get('context', {})
+
+        # Extract actor info
+        actor_mbox = actor.get('mbox', '').replace('mailto:', '')
+        if not actor_mbox and 'account' in actor:
+            actor_mbox = actor['account'].get('name', 'unknown')
+        actor_name = actor.get('name', actor_mbox)
+
+        # Try to find user by email
+        actor_user = None
+        if actor_mbox:
+            from accounts.models import User
+            actor_user = User.objects.filter(email=actor_mbox).first()
+
+        if not actor_user and credential and credential.created_by:
+            # Use credential creator as fallback
+            actor_user = credential.created_by
+
+        if not actor_user:
+            # Raise error - we need a user reference
+            raise ValueError("Cannot determine actor user")
+
+        # Create statement
+        statement = XAPIStatement(
+            actor_user=actor_user,
+            actor_mbox=actor_mbox,
+            actor_name=actor_name,
+            verb_id=verb['id'],
+            verb_display=verb.get('display', {}).get('en-US', verb['id'].split('/')[-1]),
+            object_type=obj.get('objectType', 'Activity'),
+            object_id=obj['id'],
+            object_definition=obj.get('definition', {}),
+        )
+
+        # Set statement ID if provided
+        if 'id' in validated_data:
+            statement.id = validated_data['id']
+
+        # Set result fields
+        if result:
+            statement.result_success = result.get('success')
+            statement.result_response = result.get('response', '')
+            statement.result_completion = result.get('completion')
+
+            score = result.get('score', {})
+            if score:
+                statement.result_score_scaled = score.get('scaled')
+                statement.result_score_raw = score.get('raw')
+                statement.result_score_min = score.get('min')
+                statement.result_score_max = score.get('max')
+
+        # Set context fields
+        if context:
+            registration = context.get('registration')
+            if registration:
+                statement.context_registration = uuid.UUID(registration) if isinstance(registration, str) else registration
+            statement.context_extensions = context.get('extensions', {})
+
+        # Set timestamp if provided
+        timestamp = validated_data.get('timestamp')
+        if timestamp:
+            statement.timestamp = timestamp
+
+        statement.save()
+        return statement
+
+
+class AboutView(APIView):
+    """
+    xAPI About Resource.
+
+    Returns information about the LRS including supported xAPI versions.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        """Return LRS information."""
+        data = {
+            'version': [XAPI_VERSION, '1.0.2', '1.0.1', '1.0.0'],
+            'extensions': {
+                'name': 'LinguaPal LRS',
+                'description': 'Learning Record Store for LinguaPal language learning platform',
+                'conformanceLevel': 'lrs',
+            }
+        }
+
+        serializer = LRSAboutSerializer(data)
+        response = Response(serializer.data)
+        response['X-Experience-API-Version'] = XAPI_VERSION
+        return response

--- a/LinguaPal/words/views.py
+++ b/LinguaPal/words/views.py
@@ -1,3 +1,5 @@
+import uuid
+import logging
 import random
 from django.utils import timezone
 from django.db.models import Sum, Count, F, Q
@@ -5,6 +7,30 @@ from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from django.shortcuts import get_object_or_404
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# xAPI Statement 비동기 생성 헬퍼
+# =============================================================================
+
+def queue_statement_task(statement_data):
+    """xAPI Statement 생성을 비동기 태스크로 큐에 넣기"""
+    try:
+        from lrs.tasks import create_statement_task
+        create_statement_task.delay(statement_data)
+    except Exception as exc:
+        logger.warning(f"Could not queue statement creation: {exc}")
+
+
+def queue_quiz_completion_statements(quiz_data):
+    """퀴즈 완료 시 여러 Statement (COMPLETED, PASSED/FAILED) 일괄 생성"""
+    try:
+        from lrs.tasks import create_quiz_statements_task
+        create_quiz_statements_task.delay(quiz_data)
+    except Exception as exc:
+        logger.warning(f"Could not queue quiz completion statements: {exc}")
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample, OpenApiResponse
 from accounts.permissions import IsStaffRole
 from accounts.utils import APIResponse, ErrorCode
@@ -634,6 +660,18 @@ def quiz_start(request):
             choices=choices
         )
 
+    # xAPI INITIALIZED Statement 생성 (비동기)
+    registration = uuid.uuid4()
+    quiz.registration = registration  # registration 저장을 위해 모델에 필드 필요시 추가
+    from lrs.services import QuizStatementService
+    statement_data = QuizStatementService.quiz_initialized(
+        user=request.user,
+        quiz=quiz,
+        quiz_type=quiz_type,
+        registration=registration
+    )
+    queue_statement_task(statement_data)
+
     # 첫 번째 문제 포함하여 응답
     response_serializer = GanaQuizSerializer(quiz)
     first_question = quiz.questions.first()
@@ -642,7 +680,8 @@ def quiz_start(request):
         message='Quiz started',
         data={
             'quiz': response_serializer.data,
-            'current_question': GanaQuizQuestionCurrentSerializer(first_question).data if first_question else None
+            'current_question': GanaQuizQuestionCurrentSerializer(first_question).data if first_question else None,
+            'registration': str(registration)
         },
         status_code=status.HTTP_201_CREATED
     )
@@ -722,6 +761,20 @@ def quiz_answer(request, quiz_id):
         user_stats.incorrect_count += 1
     user_stats.save()
 
+    # xAPI ANSWERED Statement 생성 (비동기)
+    from lrs.services import QuizStatementService
+    registration = getattr(quiz, 'registration', None)
+    answered_data = QuizStatementService.question_answered(
+        user=request.user,
+        quiz=quiz,
+        question=question,
+        user_answer=user_answer,
+        is_correct=is_correct,
+        correct_answer=correct_answer,
+        registration=registration
+    )
+    queue_statement_task(answered_data)
+
     # 다음 문제 확인
     next_question = quiz.questions.filter(is_correct__isnull=True).first()
     quiz_completed = next_question is None
@@ -729,6 +782,14 @@ def quiz_answer(request, quiz_id):
     if quiz_completed:
         quiz.is_completed = True
         quiz.completed_at = timezone.now()
+
+        # xAPI COMPLETED, PASSED/FAILED Statement 생성 (비동기)
+        completion_statements = QuizStatementService.quiz_completed(
+            user=request.user,
+            quiz=quiz,
+            registration=registration
+        )
+        queue_quiz_completion_statements({'statements': completion_statements})
 
     quiz.save()
 
@@ -1081,6 +1142,17 @@ def word_quiz_start(request):
             choices=choices
         )
 
+    # xAPI INITIALIZED Statement 생성 (비동기)
+    registration = uuid.uuid4()
+    from lrs.services import QuizStatementService
+    statement_data = QuizStatementService.quiz_initialized(
+        user=request.user,
+        quiz=quiz,
+        quiz_type=quiz_type,
+        registration=registration
+    )
+    queue_statement_task(statement_data)
+
     # 첫 번째 문제 포함하여 응답
     response_serializer = WordQuizSerializer(quiz)
     first_question = quiz.questions.first()
@@ -1089,7 +1161,8 @@ def word_quiz_start(request):
         message='Word quiz started',
         data={
             'quiz': response_serializer.data,
-            'current_question': WordQuizQuestionCurrentSerializer(first_question).data if first_question else None
+            'current_question': WordQuizQuestionCurrentSerializer(first_question).data if first_question else None,
+            'registration': str(registration)
         },
         status_code=status.HTTP_201_CREATED
     )
@@ -1169,6 +1242,20 @@ def word_quiz_answer(request, quiz_id):
         user_stats.incorrect_count += 1
     user_stats.save()
 
+    # xAPI ANSWERED Statement 생성 (비동기)
+    from lrs.services import QuizStatementService
+    registration = getattr(quiz, 'registration', None)
+    answered_data = QuizStatementService.question_answered(
+        user=request.user,
+        quiz=quiz,
+        question=question,
+        user_answer=user_answer,
+        is_correct=is_correct,
+        correct_answer=correct_answer,
+        registration=registration
+    )
+    queue_statement_task(answered_data)
+
     # 다음 문제 확인
     next_question = quiz.questions.filter(is_correct__isnull=True).first()
     quiz_completed = next_question is None
@@ -1176,6 +1263,14 @@ def word_quiz_answer(request, quiz_id):
     if quiz_completed:
         quiz.is_completed = True
         quiz.completed_at = timezone.now()
+
+        # xAPI COMPLETED, PASSED/FAILED Statement 생성 (비동기)
+        completion_statements = QuizStatementService.quiz_completed(
+            user=request.user,
+            quiz=quiz,
+            registration=registration
+        )
+        queue_quiz_completion_statements({'statements': completion_statements})
 
     quiz.save()
 

--- a/frontend/src/components/QuizSettingsModal.tsx
+++ b/frontend/src/components/QuizSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { quizApi } from '../services/api'
+import { lrsGanaQuizApi } from '../services/lrsMiddleware'
 import type { GanaCharacterSet, GanaQuizType, GanaQuizQuestionCount } from '../types'
 
 interface QuizSettingsModalProps {
@@ -39,7 +39,7 @@ export default function QuizSettingsModal({ isOpen, onClose }: QuizSettingsModal
     setError(null)
 
     try {
-      const response = await quizApi.startQuiz({
+      const response = await lrsGanaQuizApi.startQuiz({
         character_set: characterSet,
         quiz_type: quizType,
         question_count: questionCount,

--- a/frontend/src/components/WordQuizSettingsModal.tsx
+++ b/frontend/src/components/WordQuizSettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { wordQuizApi, userApi } from '../services/api'
+import { userApi } from '../services/api'
+import { lrsWordQuizApi } from '../services/lrsMiddleware'
 import type { WordQuizType, WordQuizQuestionCount, Language } from '../types'
 
 interface WordQuizSettingsModalProps {
@@ -64,7 +65,7 @@ export default function WordQuizSettingsModal({ isOpen, onClose }: WordQuizSetti
     setError(null)
 
     try {
-      const response = await wordQuizApi.startQuiz({
+      const response = await lrsWordQuizApi.startQuiz({
         learning_language: selectedLanguage,
         quiz_type: quizType,
         question_count: questionCount,

--- a/frontend/src/hooks/useXAPI.ts
+++ b/frontend/src/hooks/useXAPI.ts
@@ -1,0 +1,186 @@
+/**
+ * useXAPI Hook
+ *
+ * React hook for integrating xAPI/LRS functionality into quiz components.
+ * Provides session management and event subscription.
+ */
+
+import { useEffect, useCallback, useState, useRef } from 'react'
+import { sessionManager } from '../services/lrs'
+import {
+  lrsGanaQuizApi,
+  lrsWordQuizApi,
+  subscribeToQuizEvents,
+} from '../services/lrsMiddleware'
+import type { QuizSession, XAPIStatement } from '../types/xapi'
+
+interface QuizEvent {
+  type: 'start' | 'answer' | 'complete'
+  quizType: 'gana' | 'word'
+  quizId: number
+  session: QuizSession
+  statement?: XAPIStatement | null
+  data?: Record<string, unknown>
+}
+
+interface UseXAPIOptions {
+  quizType: 'gana' | 'word'
+  quizId?: number
+  onStart?: (event: QuizEvent) => void
+  onAnswer?: (event: QuizEvent) => void
+  onComplete?: (event: QuizEvent) => void
+}
+
+interface UseXAPIReturn {
+  // Current session
+  session: QuizSession | null
+
+  // API methods (LRS-enhanced)
+  api: typeof lrsGanaQuizApi | typeof lrsWordQuizApi
+
+  // Session management
+  getSession: () => QuizSession | null
+  clearSession: () => void
+
+  // Event history (last N events)
+  recentEvents: QuizEvent[]
+}
+
+/**
+ * Hook for using xAPI/LRS in quiz components
+ */
+export function useXAPI(options: UseXAPIOptions): UseXAPIReturn {
+  const { quizType, quizId, onStart, onAnswer, onComplete } = options
+
+  const [session, setSession] = useState<QuizSession | null>(null)
+  const [recentEvents, setRecentEvents] = useState<QuizEvent[]>([])
+  const callbacksRef = useRef({ onStart, onAnswer, onComplete })
+
+  // Update refs when callbacks change
+  useEffect(() => {
+    callbacksRef.current = { onStart, onAnswer, onComplete }
+  }, [onStart, onAnswer, onComplete])
+
+  // Get the appropriate API
+  const api = quizType === 'gana' ? lrsGanaQuizApi : lrsWordQuizApi
+
+  // Load session on mount or when quizId changes
+  useEffect(() => {
+    if (quizId) {
+      const existingSession = sessionManager.getSession(quizType, quizId)
+      setSession(existingSession)
+    }
+  }, [quizType, quizId])
+
+  // Subscribe to quiz events
+  useEffect(() => {
+    const unsubscribe = subscribeToQuizEvents((event) => {
+      // Only handle events for our quiz type
+      if (event.quizType !== quizType) return
+
+      // If we have a specific quizId, only handle events for that quiz
+      if (quizId && event.quizId !== quizId) return
+
+      // Update session state
+      setSession(event.session)
+
+      // Add to recent events (keep last 50)
+      setRecentEvents((prev) => [...prev.slice(-49), event])
+
+      // Call appropriate callback
+      const callbacks = callbacksRef.current
+      switch (event.type) {
+        case 'start':
+          callbacks.onStart?.(event)
+          break
+        case 'answer':
+          callbacks.onAnswer?.(event)
+          break
+        case 'complete':
+          callbacks.onComplete?.(event)
+          break
+      }
+    })
+
+    return unsubscribe
+  }, [quizType, quizId])
+
+  // Get current session
+  const getSession = useCallback((): QuizSession | null => {
+    if (!quizId) return null
+    return sessionManager.getSession(quizType, quizId)
+  }, [quizType, quizId])
+
+  // Clear session
+  const clearSession = useCallback((): void => {
+    if (quizId) {
+      sessionManager.endSession(quizType, quizId)
+      setSession(null)
+    }
+  }, [quizType, quizId])
+
+  return {
+    session,
+    api,
+    getSession,
+    clearSession,
+    recentEvents,
+  }
+}
+
+/**
+ * Hook for Gana Quiz with xAPI
+ */
+export function useGanaQuizXAPI(
+  quizId?: number,
+  callbacks?: {
+    onStart?: (event: QuizEvent) => void
+    onAnswer?: (event: QuizEvent) => void
+    onComplete?: (event: QuizEvent) => void
+  }
+) {
+  return useXAPI({
+    quizType: 'gana',
+    quizId,
+    ...callbacks,
+  })
+}
+
+/**
+ * Hook for Word Quiz with xAPI
+ */
+export function useWordQuizXAPI(
+  quizId?: number,
+  callbacks?: {
+    onStart?: (event: QuizEvent) => void
+    onAnswer?: (event: QuizEvent) => void
+    onComplete?: (event: QuizEvent) => void
+  }
+) {
+  return useXAPI({
+    quizType: 'word',
+    quizId,
+    ...callbacks,
+  })
+}
+
+/**
+ * Hook for subscribing to all quiz events (useful for analytics/debugging)
+ */
+export function useQuizEventSubscription(
+  callback: (event: QuizEvent) => void
+): void {
+  const callbackRef = useRef(callback)
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    return subscribeToQuizEvents((event) => {
+      callbackRef.current(event)
+    })
+  }, [])
+}
+
+export default useXAPI

--- a/frontend/src/pages/QuizDashboardPage.tsx
+++ b/frontend/src/pages/QuizDashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { quizApi } from '../services/api'
+import { lrsGanaQuizApi } from '../services/lrsMiddleware'
 import Header from '../components/Header'
 import QuizSettingsModal from '../components/QuizSettingsModal'
 import type { QuizStats, GanaQuizListItem } from '../types'
@@ -16,8 +16,8 @@ export default function QuizDashboardPage() {
       try {
         setIsLoading(true)
         const [statsResponse, historyResponse] = await Promise.all([
-          quizApi.getQuizStats(),
-          quizApi.getQuizHistory({ limit: 10 }),
+          lrsGanaQuizApi.getQuizStats(),
+          lrsGanaQuizApi.getQuizHistory({ limit: 10 }),
         ])
 
         if (statsResponse.data.success) {

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import axios from 'axios'
-import { quizApi } from '../services/api'
+import { lrsGanaQuizApi } from '../services/lrsMiddleware'
 import Header from '../components/Header'
 import type { GanaQuiz, CurrentQuestion, QuizProgress, QuizAnswerResponse } from '../types'
 
@@ -28,7 +28,7 @@ export default function QuizPage() {
       setIsLoading(true)
 
       // 먼저 퀴즈 상세 정보 조회
-      const quizResponse = await quizApi.getQuizDetail(parseInt(quizId))
+      const quizResponse = await lrsGanaQuizApi.getQuizDetail(parseInt(quizId))
 
       if (!quizResponse.data.success) {
         setError('퀴즈를 찾을 수 없습니다.')
@@ -46,7 +46,7 @@ export default function QuizPage() {
 
       // 현재 문제 조회
       try {
-        const questionResponse = await quizApi.getCurrentQuestion(parseInt(quizId))
+        const questionResponse = await lrsGanaQuizApi.getCurrentQuestion(parseInt(quizId))
         if (questionResponse.data.success) {
           setCurrentQuestion(questionResponse.data.data.question)
           setProgress(questionResponse.data.data.progress)
@@ -85,7 +85,7 @@ export default function QuizPage() {
 
     setIsSubmitting(true)
     try {
-      const response = await quizApi.submitAnswer(parseInt(quizId), {
+      const response = await lrsGanaQuizApi.submitAnswer(parseInt(quizId), {
         question_id: currentQuestion.id,
         answer: userAnswer.trim(),
       })

--- a/frontend/src/pages/WordQuizDashboardPage.tsx
+++ b/frontend/src/pages/WordQuizDashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { wordQuizApi } from '../services/api'
+import { lrsWordQuizApi } from '../services/lrsMiddleware'
 import Header from '../components/Header'
 import WordQuizSettingsModal from '../components/WordQuizSettingsModal'
 import type { WordQuizStats, WordQuizListItem } from '../types'
@@ -16,8 +16,8 @@ export default function WordQuizDashboardPage() {
       try {
         setIsLoading(true)
         const [statsResponse, historyResponse] = await Promise.all([
-          wordQuizApi.getQuizStats(),
-          wordQuizApi.getQuizHistory({ limit: 10 }),
+          lrsWordQuizApi.getQuizStats(),
+          lrsWordQuizApi.getQuizHistory({ limit: 10 }),
         ])
 
         if (statsResponse.data.success) {

--- a/frontend/src/pages/WordQuizPage.tsx
+++ b/frontend/src/pages/WordQuizPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import axios from 'axios'
-import { wordQuizApi } from '../services/api'
+import { lrsWordQuizApi } from '../services/lrsMiddleware'
 import Header from '../components/Header'
 import type { WordQuiz, CurrentQuestion, QuizProgress, WordQuizAnswerResponse } from '../types'
 
@@ -26,7 +26,7 @@ export default function WordQuizPage() {
 
     try {
       setIsLoading(true)
-      const quizResponse = await wordQuizApi.getQuizDetail(parseInt(quizId))
+      const quizResponse = await lrsWordQuizApi.getQuizDetail(parseInt(quizId))
 
       if (!quizResponse.data.success) {
         setError('퀴즈를 찾을 수 없습니다.')
@@ -42,7 +42,7 @@ export default function WordQuizPage() {
       }
 
       try {
-        const questionResponse = await wordQuizApi.getCurrentQuestion(parseInt(quizId))
+        const questionResponse = await lrsWordQuizApi.getCurrentQuestion(parseInt(quizId))
         if (questionResponse.data.success) {
           setCurrentQuestion(questionResponse.data.data.question)
           setProgress(questionResponse.data.data.progress)
@@ -80,7 +80,7 @@ export default function WordQuizPage() {
 
     setIsSubmitting(true)
     try {
-      const response = await wordQuizApi.submitAnswer(parseInt(quizId), {
+      const response = await lrsWordQuizApi.submitAnswer(parseInt(quizId), {
         question_id: currentQuestion.id,
         answer: userAnswer.trim(),
       })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import type {
   ApiResponse,
-  AuthTokens,
   User,
   UserProfile,
   Language,

--- a/frontend/src/services/lrs.ts
+++ b/frontend/src/services/lrs.ts
@@ -1,0 +1,387 @@
+/**
+ * LRS (Learning Record Store) Service
+ *
+ * Service for managing xAPI statements and quiz sessions.
+ * Handles session tracking and provides helpers for xAPI statement creation.
+ */
+
+import type {
+  QuizSession,
+  XAPIStatement,
+  XAPIActor,
+  XAPIVerb,
+  XAPIObject,
+  XAPIResult,
+  XAPIContext,
+} from '../types/xapi'
+import { XAPIVerbs, XAPIActivityTypes } from '../types/xapi'
+
+const LINGUAPAL_BASE_IRI = 'https://linguapal.com'
+
+// Session storage key
+const SESSION_STORAGE_KEY = 'lrs_quiz_sessions'
+
+/**
+ * Generate a UUID v4
+ */
+export function generateUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+/**
+ * Get current user info for xAPI Actor
+ */
+function getCurrentActor(): XAPIActor | null {
+  const userStr = localStorage.getItem('user')
+  if (!userStr) return null
+
+  try {
+    const user = JSON.parse(userStr)
+    return {
+      objectType: 'Agent',
+      mbox: `mailto:${user.email}`,
+      name: user.name || user.email,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Session Manager for quiz tracking
+ */
+class QuizSessionManager {
+  private sessions: Map<string, QuizSession> = new Map()
+
+  constructor() {
+    this.loadFromStorage()
+  }
+
+  private loadFromStorage(): void {
+    try {
+      const stored = sessionStorage.getItem(SESSION_STORAGE_KEY)
+      if (stored) {
+        const sessions = JSON.parse(stored) as QuizSession[]
+        sessions.forEach((session) => {
+          const key = this.getSessionKey(session.quizType, session.quizId)
+          this.sessions.set(key, session)
+        })
+      }
+    } catch (error) {
+      console.warn('Failed to load quiz sessions from storage:', error)
+    }
+  }
+
+  private saveToStorage(): void {
+    try {
+      const sessions = Array.from(this.sessions.values())
+      sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(sessions))
+    } catch (error) {
+      console.warn('Failed to save quiz sessions to storage:', error)
+    }
+  }
+
+  private getSessionKey(quizType: 'gana' | 'word', quizId: number): string {
+    return `${quizType}_${quizId}`
+  }
+
+  /**
+   * Start a new quiz session
+   */
+  startSession(
+    quizType: 'gana' | 'word',
+    quizId: number,
+    totalQuestions: number,
+    registration?: string
+  ): QuizSession {
+    const session: QuizSession = {
+      quizId,
+      quizType,
+      registration: registration || generateUUID(),
+      startedAt: new Date().toISOString(),
+      totalQuestions,
+      currentQuestion: 1,
+      correctCount: 0,
+    }
+
+    const key = this.getSessionKey(quizType, quizId)
+    this.sessions.set(key, session)
+    this.saveToStorage()
+
+    return session
+  }
+
+  /**
+   * Get an existing session
+   */
+  getSession(quizType: 'gana' | 'word', quizId: number): QuizSession | null {
+    const key = this.getSessionKey(quizType, quizId)
+    return this.sessions.get(key) || null
+  }
+
+  /**
+   * Update session progress
+   */
+  updateSession(
+    quizType: 'gana' | 'word',
+    quizId: number,
+    updates: Partial<Pick<QuizSession, 'currentQuestion' | 'correctCount'>>
+  ): QuizSession | null {
+    const session = this.getSession(quizType, quizId)
+    if (!session) return null
+
+    const key = this.getSessionKey(quizType, quizId)
+    const updatedSession = { ...session, ...updates }
+    this.sessions.set(key, updatedSession)
+    this.saveToStorage()
+
+    return updatedSession
+  }
+
+  /**
+   * End and remove a session
+   */
+  endSession(quizType: 'gana' | 'word', quizId: number): QuizSession | null {
+    const key = this.getSessionKey(quizType, quizId)
+    const session = this.sessions.get(key)
+    if (session) {
+      this.sessions.delete(key)
+      this.saveToStorage()
+    }
+    return session || null
+  }
+
+  /**
+   * Clear all sessions
+   */
+  clearAllSessions(): void {
+    this.sessions.clear()
+    sessionStorage.removeItem(SESSION_STORAGE_KEY)
+  }
+}
+
+// Singleton instance
+export const sessionManager = new QuizSessionManager()
+
+/**
+ * xAPI Statement Builder
+ */
+export class StatementBuilder {
+  private actor: XAPIActor | null = null
+  private verb: XAPIVerb | null = null
+  private object: XAPIObject | null = null
+  private result: XAPIResult | null = null
+  private context: XAPIContext | null = null
+  private timestamp: string | null = null
+
+  constructor() {
+    this.actor = getCurrentActor()
+  }
+
+  setVerb(verbId: string, display: string): this {
+    this.verb = {
+      id: verbId,
+      display: { 'en-US': display, ko: display },
+    }
+    return this
+  }
+
+  setActivity(
+    activityId: string,
+    name: string,
+    activityType: string = XAPIActivityTypes.ASSESSMENT,
+    description?: string
+  ): this {
+    const fullId = activityId.startsWith('http')
+      ? activityId
+      : `${LINGUAPAL_BASE_IRI}/${activityId}`
+
+    this.object = {
+      objectType: 'Activity',
+      id: fullId,
+      definition: {
+        type: activityType,
+        name: { ko: name },
+        ...(description && { description: { ko: description } }),
+      },
+    }
+    return this
+  }
+
+  setResult(result: XAPIResult): this {
+    this.result = result
+    return this
+  }
+
+  setContext(registration?: string, extensions?: Record<string, unknown>): this {
+    this.context = {
+      ...(registration && { registration }),
+      ...(extensions && { extensions }),
+    }
+    return this
+  }
+
+  setTimestamp(timestamp?: string): this {
+    this.timestamp = timestamp || new Date().toISOString()
+    return this
+  }
+
+  build(): XAPIStatement | null {
+    if (!this.actor || !this.verb || !this.object) {
+      console.warn('Cannot build statement: missing required fields')
+      return null
+    }
+
+    const statement: XAPIStatement = {
+      actor: this.actor,
+      verb: this.verb,
+      object: this.object,
+    }
+
+    if (this.result) statement.result = this.result
+    if (this.context) statement.context = this.context
+    if (this.timestamp) statement.timestamp = this.timestamp
+
+    return statement
+  }
+}
+
+/**
+ * Pre-built statement creators for common quiz events
+ */
+export const QuizStatements = {
+  /**
+   * Create INITIALIZED statement for quiz start
+   */
+  initialized(
+    quizType: 'gana' | 'word',
+    quizId: number,
+    quizName: string,
+    registration: string,
+    extensions?: Record<string, unknown>
+  ): XAPIStatement | null {
+    return new StatementBuilder()
+      .setVerb(XAPIVerbs.INITIALIZED, 'initialized')
+      .setActivity(
+        `quiz/${quizType}/${quizId}`,
+        quizName,
+        XAPIActivityTypes.ASSESSMENT
+      )
+      .setContext(registration, extensions)
+      .setTimestamp()
+      .build()
+  },
+
+  /**
+   * Create ANSWERED statement for question response
+   */
+  answered(
+    quizType: 'gana' | 'word',
+    quizId: number,
+    questionId: number,
+    questionNumber: number,
+    userAnswer: string,
+    isCorrect: boolean,
+    registration?: string,
+    extensions?: Record<string, unknown>
+  ): XAPIStatement | null {
+    return new StatementBuilder()
+      .setVerb(XAPIVerbs.ANSWERED, 'answered')
+      .setActivity(
+        `quiz/${quizType}/${quizId}/question/${questionId}`,
+        `문제 #${questionNumber}`,
+        XAPIActivityTypes.QUESTION
+      )
+      .setResult({
+        success: isCorrect,
+        response: userAnswer,
+      })
+      .setContext(registration, {
+        questionNumber,
+        ...extensions,
+      })
+      .setTimestamp()
+      .build()
+  },
+
+  /**
+   * Create COMPLETED statement for quiz completion
+   */
+  completed(
+    quizType: 'gana' | 'word',
+    quizId: number,
+    quizName: string,
+    correctCount: number,
+    totalQuestions: number,
+    registration?: string
+  ): XAPIStatement | null {
+    const scoreScaled = totalQuestions > 0 ? correctCount / totalQuestions : 0
+
+    return new StatementBuilder()
+      .setVerb(XAPIVerbs.COMPLETED, 'completed')
+      .setActivity(
+        `quiz/${quizType}/${quizId}`,
+        quizName,
+        XAPIActivityTypes.ASSESSMENT
+      )
+      .setResult({
+        completion: true,
+        score: {
+          scaled: scoreScaled,
+          raw: correctCount,
+          min: 0,
+          max: totalQuestions,
+        },
+      })
+      .setContext(registration)
+      .setTimestamp()
+      .build()
+  },
+
+  /**
+   * Create PASSED or FAILED statement based on score
+   */
+  passedOrFailed(
+    quizType: 'gana' | 'word',
+    quizId: number,
+    quizName: string,
+    correctCount: number,
+    totalQuestions: number,
+    masteryScore: number = 0.8,
+    registration?: string
+  ): XAPIStatement | null {
+    const scoreScaled = totalQuestions > 0 ? correctCount / totalQuestions : 0
+    const passed = scoreScaled >= masteryScore
+
+    return new StatementBuilder()
+      .setVerb(
+        passed ? XAPIVerbs.PASSED : XAPIVerbs.FAILED,
+        passed ? 'passed' : 'failed'
+      )
+      .setActivity(
+        `quiz/${quizType}/${quizId}`,
+        quizName,
+        XAPIActivityTypes.ASSESSMENT
+      )
+      .setResult({
+        success: passed,
+        score: {
+          scaled: scoreScaled,
+        },
+      })
+      .setContext(registration, { masteryScore })
+      .setTimestamp()
+      .build()
+  },
+}
+
+export default {
+  sessionManager,
+  StatementBuilder,
+  QuizStatements,
+  generateUUID,
+}

--- a/frontend/src/services/lrsMiddleware.ts
+++ b/frontend/src/services/lrsMiddleware.ts
@@ -1,0 +1,397 @@
+/**
+ * LRS Middleware
+ *
+ * Middleware that wraps quiz API calls to automatically handle
+ * xAPI statement creation and session management.
+ *
+ * The backend already creates statements asynchronously, so this middleware:
+ * 1. Manages local session state (registration UUID)
+ * 2. Tracks quiz progress client-side
+ * 3. Can optionally send additional client-side statements
+ */
+
+import type { AxiosResponse } from 'axios'
+import { quizApi, wordQuizApi } from './api'
+import { sessionManager, QuizStatements, generateUUID } from './lrs'
+import type { ApiResponse } from '../types'
+import type {
+  QuizStartRequest,
+  QuizStartResponse,
+  QuizAnswerRequest,
+  QuizAnswerResponse,
+  WordQuizStartRequest,
+  WordQuizStartResponse,
+  WordQuizAnswerRequest,
+  WordQuizAnswerResponse,
+} from '../types'
+import type { QuizSession, XAPIStatement } from '../types/xapi'
+
+// Event callback types
+type QuizEventCallback = (event: {
+  type: 'start' | 'answer' | 'complete'
+  quizType: 'gana' | 'word'
+  quizId: number
+  session: QuizSession
+  statement?: XAPIStatement | null
+  data?: Record<string, unknown>
+}) => void
+
+// Global event listeners
+const eventListeners: Set<QuizEventCallback> = new Set()
+
+/**
+ * Subscribe to quiz events
+ */
+export function subscribeToQuizEvents(callback: QuizEventCallback): () => void {
+  eventListeners.add(callback)
+  return () => eventListeners.delete(callback)
+}
+
+/**
+ * Emit quiz event to all listeners
+ */
+function emitEvent(event: Parameters<QuizEventCallback>[0]): void {
+  eventListeners.forEach((callback) => {
+    try {
+      callback(event)
+    } catch (error) {
+      console.error('Quiz event callback error:', error)
+    }
+  })
+}
+
+/**
+ * Get quiz name for statements
+ */
+function getQuizName(quizType: 'gana' | 'word', quizId: number): string {
+  return quizType === 'gana' ? `가나 퀴즈 #${quizId}` : `단어 퀴즈 #${quizId}`
+}
+
+/**
+ * LRS-enhanced Gana Quiz API
+ */
+export const lrsGanaQuizApi = {
+  /**
+   * Start quiz with LRS session tracking
+   */
+  async startQuiz(
+    data: QuizStartRequest
+  ): Promise<AxiosResponse<ApiResponse<QuizStartResponse & { registration: string }>>> {
+    const response = await quizApi.startQuiz(data)
+
+    if (response.data.success && response.data.data) {
+      const quiz = response.data.data.quiz
+      // Backend returns registration in response
+      const registration =
+        (response.data.data as unknown as { registration?: string }).registration ||
+        generateUUID()
+
+      // Start local session
+      const session = sessionManager.startSession(
+        'gana',
+        quiz.id,
+        quiz.total_questions,
+        registration
+      )
+
+      // Create statement for client-side tracking (optional)
+      const statement = QuizStatements.initialized(
+        'gana',
+        quiz.id,
+        getQuizName('gana', quiz.id),
+        registration,
+        {
+          character_set: data.character_set,
+          quiz_type: data.quiz_type,
+          total_questions: quiz.total_questions,
+        }
+      )
+
+      // Emit event
+      emitEvent({
+        type: 'start',
+        quizType: 'gana',
+        quizId: quiz.id,
+        session,
+        statement,
+        data: { characterSet: data.character_set, quizType: data.quiz_type },
+      })
+
+      // Return with registration added to response data
+      return {
+        ...response,
+        data: {
+          ...response.data,
+          data: {
+            ...response.data.data,
+            registration,
+          },
+        },
+      } as AxiosResponse<ApiResponse<QuizStartResponse & { registration: string }>>
+    }
+
+    return response as AxiosResponse<ApiResponse<QuizStartResponse & { registration: string }>>
+  },
+
+  /**
+   * Submit answer with LRS tracking
+   */
+  async submitAnswer(
+    quizId: number,
+    data: QuizAnswerRequest
+  ): Promise<AxiosResponse<ApiResponse<QuizAnswerResponse>>> {
+    const response = await quizApi.submitAnswer(quizId, data)
+
+    if (response.data.success && response.data.data) {
+      const result = response.data.data
+      const session = sessionManager.getSession('gana', quizId)
+
+      if (session) {
+        // Update session
+        const updatedSession = sessionManager.updateSession('gana', quizId, {
+          currentQuestion: session.currentQuestion + 1,
+          correctCount: session.correctCount + (result.is_correct ? 1 : 0),
+        })
+
+        // Create answered statement
+        const answeredStatement = QuizStatements.answered(
+          'gana',
+          quizId,
+          data.question_id,
+          session.currentQuestion,
+          data.answer,
+          result.is_correct,
+          session.registration,
+          { correctAnswer: result.correct_answer }
+        )
+
+        // Emit answer event
+        emitEvent({
+          type: 'answer',
+          quizType: 'gana',
+          quizId,
+          session: updatedSession || session,
+          statement: answeredStatement,
+          data: {
+            questionId: data.question_id,
+            isCorrect: result.is_correct,
+            correctAnswer: result.correct_answer,
+          },
+        })
+
+        // Handle completion
+        if (result.quiz_completed && updatedSession) {
+          const completedStatement = QuizStatements.completed(
+            'gana',
+            quizId,
+            getQuizName('gana', quizId),
+            updatedSession.correctCount,
+            updatedSession.totalQuestions,
+            session.registration
+          )
+
+          // Emit complete event
+          emitEvent({
+            type: 'complete',
+            quizType: 'gana',
+            quizId,
+            session: updatedSession,
+            statement: completedStatement,
+            data: {
+              correctCount: updatedSession.correctCount,
+              totalQuestions: updatedSession.totalQuestions,
+              scorePercentage:
+                (updatedSession.correctCount / updatedSession.totalQuestions) * 100,
+            },
+          })
+
+          // End session
+          sessionManager.endSession('gana', quizId)
+        }
+      }
+    }
+
+    return response
+  },
+
+  /**
+   * Get current session
+   */
+  getSession(quizId: number): QuizSession | null {
+    return sessionManager.getSession('gana', quizId)
+  },
+
+  // Passthrough methods
+  getQuizDetail: quizApi.getQuizDetail,
+  getCurrentQuestion: quizApi.getCurrentQuestion,
+  getQuizHistory: quizApi.getQuizHistory,
+  getQuizStats: quizApi.getQuizStats,
+}
+
+/**
+ * LRS-enhanced Word Quiz API
+ */
+export const lrsWordQuizApi = {
+  /**
+   * Start quiz with LRS session tracking
+   */
+  async startQuiz(
+    data: WordQuizStartRequest
+  ): Promise<AxiosResponse<ApiResponse<WordQuizStartResponse & { registration: string }>>> {
+    const response = await wordQuizApi.startQuiz(data)
+
+    if (response.data.success && response.data.data) {
+      const quiz = response.data.data.quiz
+      const registration =
+        (response.data.data as unknown as { registration?: string }).registration ||
+        generateUUID()
+
+      // Start local session
+      const session = sessionManager.startSession(
+        'word',
+        quiz.id,
+        quiz.total_questions,
+        registration
+      )
+
+      // Create statement
+      const statement = QuizStatements.initialized(
+        'word',
+        quiz.id,
+        getQuizName('word', quiz.id),
+        registration,
+        {
+          learning_language: quiz.learning_language_code,
+          quiz_type: data.quiz_type,
+          total_questions: quiz.total_questions,
+        }
+      )
+
+      // Emit event
+      emitEvent({
+        type: 'start',
+        quizType: 'word',
+        quizId: quiz.id,
+        session,
+        statement,
+        data: {
+          learningLanguage: quiz.learning_language_code,
+          quizType: data.quiz_type,
+        },
+      })
+
+      return {
+        ...response,
+        data: {
+          ...response.data,
+          data: {
+            ...response.data.data,
+            registration,
+          },
+        },
+      } as AxiosResponse<ApiResponse<WordQuizStartResponse & { registration: string }>>
+    }
+
+    return response as AxiosResponse<ApiResponse<WordQuizStartResponse & { registration: string }>>
+  },
+
+  /**
+   * Submit answer with LRS tracking
+   */
+  async submitAnswer(
+    quizId: number,
+    data: WordQuizAnswerRequest
+  ): Promise<AxiosResponse<ApiResponse<WordQuizAnswerResponse>>> {
+    const response = await wordQuizApi.submitAnswer(quizId, data)
+
+    if (response.data.success && response.data.data) {
+      const result = response.data.data
+      const session = sessionManager.getSession('word', quizId)
+
+      if (session) {
+        // Update session
+        const updatedSession = sessionManager.updateSession('word', quizId, {
+          currentQuestion: session.currentQuestion + 1,
+          correctCount: session.correctCount + (result.is_correct ? 1 : 0),
+        })
+
+        // Create answered statement
+        const answeredStatement = QuizStatements.answered(
+          'word',
+          quizId,
+          data.question_id,
+          session.currentQuestion,
+          data.answer,
+          result.is_correct,
+          session.registration,
+          { correctAnswer: result.correct_answer }
+        )
+
+        // Emit answer event
+        emitEvent({
+          type: 'answer',
+          quizType: 'word',
+          quizId,
+          session: updatedSession || session,
+          statement: answeredStatement,
+          data: {
+            questionId: data.question_id,
+            isCorrect: result.is_correct,
+            correctAnswer: result.correct_answer,
+          },
+        })
+
+        // Handle completion
+        if (result.quiz_completed && updatedSession) {
+          const completedStatement = QuizStatements.completed(
+            'word',
+            quizId,
+            getQuizName('word', quizId),
+            updatedSession.correctCount,
+            updatedSession.totalQuestions,
+            session.registration
+          )
+
+          // Emit complete event
+          emitEvent({
+            type: 'complete',
+            quizType: 'word',
+            quizId,
+            session: updatedSession,
+            statement: completedStatement,
+            data: {
+              correctCount: updatedSession.correctCount,
+              totalQuestions: updatedSession.totalQuestions,
+              scorePercentage:
+                (updatedSession.correctCount / updatedSession.totalQuestions) * 100,
+            },
+          })
+
+          // End session
+          sessionManager.endSession('word', quizId)
+        }
+      }
+    }
+
+    return response
+  },
+
+  /**
+   * Get current session
+   */
+  getSession(quizId: number): QuizSession | null {
+    return sessionManager.getSession('word', quizId)
+  },
+
+  // Passthrough methods
+  getQuizDetail: wordQuizApi.getQuizDetail,
+  getCurrentQuestion: wordQuizApi.getCurrentQuestion,
+  getQuizHistory: wordQuizApi.getQuizHistory,
+  getQuizStats: wordQuizApi.getQuizStats,
+}
+
+export default {
+  ganaQuiz: lrsGanaQuizApi,
+  wordQuiz: lrsWordQuizApi,
+  subscribeToQuizEvents,
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -260,3 +260,6 @@ export interface WordQuizStats {
   weakest_words: UserWordStats[]
   strongest_words: UserWordStats[]
 }
+
+// Re-export xAPI types
+export * from './xapi'

--- a/frontend/src/types/xapi.ts
+++ b/frontend/src/types/xapi.ts
@@ -1,0 +1,124 @@
+/**
+ * xAPI (Experience API) Types
+ *
+ * Types for xAPI statements and LRS integration.
+ * Based on xAPI 1.0.3 specification.
+ */
+
+// xAPI Verbs
+export const XAPIVerbs = {
+  INITIALIZED: 'http://adlnet.gov/expapi/verbs/initialized',
+  TERMINATED: 'http://adlnet.gov/expapi/verbs/terminated',
+  ANSWERED: 'http://adlnet.gov/expapi/verbs/answered',
+  PROGRESSED: 'http://adlnet.gov/expapi/verbs/progressed',
+  COMPLETED: 'http://adlnet.gov/expapi/verbs/completed',
+  PASSED: 'http://adlnet.gov/expapi/verbs/passed',
+  FAILED: 'http://adlnet.gov/expapi/verbs/failed',
+} as const
+
+export type XAPIVerbId = (typeof XAPIVerbs)[keyof typeof XAPIVerbs]
+
+// xAPI Actor (Agent)
+export interface XAPIActor {
+  objectType: 'Agent'
+  mbox: string // mailto:email@example.com
+  name?: string
+}
+
+// xAPI Verb
+export interface XAPIVerb {
+  id: string
+  display: Record<string, string>
+}
+
+// xAPI Activity Definition
+export interface XAPIActivityDefinition {
+  type?: string
+  name?: Record<string, string>
+  description?: Record<string, string>
+}
+
+// xAPI Object (Activity)
+export interface XAPIObject {
+  objectType: 'Activity'
+  id: string
+  definition?: XAPIActivityDefinition
+}
+
+// xAPI Score
+export interface XAPIScore {
+  scaled?: number // -1 to 1
+  raw?: number
+  min?: number
+  max?: number
+}
+
+// xAPI Result
+export interface XAPIResult {
+  success?: boolean
+  completion?: boolean
+  response?: string
+  score?: XAPIScore
+  duration?: string // ISO 8601 duration
+}
+
+// xAPI Context
+export interface XAPIContext {
+  registration?: string // UUID
+  extensions?: Record<string, unknown>
+}
+
+// xAPI Statement
+export interface XAPIStatement {
+  id?: string
+  actor: XAPIActor
+  verb: XAPIVerb
+  object: XAPIObject
+  result?: XAPIResult
+  context?: XAPIContext
+  timestamp?: string
+}
+
+// Quiz Session for tracking xAPI registration
+export interface QuizSession {
+  quizId: number
+  quizType: 'gana' | 'word'
+  registration: string // UUID
+  startedAt: string
+  totalQuestions: number
+  currentQuestion: number
+  correctCount: number
+}
+
+// LRS API Response types
+export interface LRSStatementResponse {
+  id: string
+}
+
+export interface LRSAboutResponse {
+  version: string[]
+  extensions?: Record<string, unknown>
+}
+
+// Quiz Event Types for middleware
+export type QuizEventType =
+  | 'quiz_start'
+  | 'question_answered'
+  | 'quiz_completed'
+  | 'quiz_abandoned'
+
+export interface QuizEvent {
+  type: QuizEventType
+  quizId: number
+  quizType: 'gana' | 'word'
+  registration?: string
+  data?: Record<string, unknown>
+}
+
+// Activity Types
+export const XAPIActivityTypes = {
+  ASSESSMENT: 'http://adlnet.gov/expapi/activities/assessment',
+  QUESTION: 'http://adlnet.gov/expapi/activities/question',
+  COURSE: 'http://adlnet.gov/expapi/activities/course',
+  MODULE: 'http://adlnet.gov/expapi/activities/module',
+} as const

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,5 +45,5 @@ celery>=5.3.0
 django-celery-results>=2.5.0
 kombu>=5.3.0
 
-# Elasticsearch (must match server version 8.x)
-elasticsearch>=8.0.0,<9.0.0
+# Elasticsearch (pinned to match server version 8.11.x)
+elasticsearch>=8.11.0,<8.12.0


### PR DESCRIPTION
Backend - xAPI/cmi5 핵심 로직
- StatementBuilder 서비스 (lrs/services.py) - xAPI Statement 생성 패턴
- Celery Tasks (lrs/tasks.py) - 비동기 Statement 생성 및 ES 인덱싱
- Django Signals (lrs/signals.py) - DB 저장 시 자동 ES 인덱싱
- xAPI 엔드포인트 (lrs/views/xapi.py) - Statement POST/PUT/GET API
- cmi5 엔드포인트 (lrs/views/cmi5.py) - Launch, Session 관리 API
- LRS 인증 (lrs/authentication.py) - Basic Auth 인증

Backend - Dashboard & Management Commands
- Dashboard API (lrs/views/dashboard.py) - Admin 통계 API
- backfill_statements - 기존 GanaQuiz/WordQuiz → xAPI Statement 변환
- reindex_statements - Elasticsearch bulk 인덱싱
- create_es_indices - ES 인덱스 생성

Frontend - LRS 미들웨어
- LRS Middleware (frontend/src/services/lrsMiddleware.ts) - Quiz API 래퍼
- useXAPI Hook (frontend/src/hooks/useXAPI.ts) - React 훅
- xAPI 타입 (frontend/src/types/xapi.ts) - TypeScript 타입 정의

resolve #29